### PR TITLE
Fix: long string starting with newline, escaping `\n\r` newlines

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,16 +1,19 @@
 //! Tests with Lua literals
 #![allow(dead_code)]
 
+use std::borrow::Borrow;
+
 use serde_luaq::{lua_value, return_statement, script, LuaValue};
 
 /// Parse a buffer of Lua code and expect no remaining value.
-pub fn check(lua: &'_ [u8], expected: LuaValue<'_>) {
+pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
+    let expected: &LuaValue<'a> = expected.borrow();
     let actual = lua_value(lua).unwrap();
 
     if expected.is_nan() {
         assert!(actual.is_nan(), "lua: {}", lua.escape_ascii());
     } else {
-        assert_eq!(actual, expected, "lua: {}", lua.escape_ascii());
+        assert_eq!(&actual, expected, "lua: {}", lua.escape_ascii());
     }
 
     let mut s = Vec::with_capacity(lua.len() + 4);
@@ -23,7 +26,7 @@ pub fn check(lua: &'_ [u8], expected: LuaValue<'_>) {
     if expected.is_nan() {
         assert!(actual.is_nan(), "lua: {}", s.escape_ascii());
     } else {
-        assert_eq!(actual, expected, "lua: {}", s.escape_ascii());
+        assert_eq!(&actual, expected, "lua: {}", s.escape_ascii());
     }
 }
 

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -117,6 +117,11 @@ fn long_string() {
     check(b"[[\r\nhello]]", &expected);
     check(b"[[\n\rhello]]", &expected);
 
+    check(b"[=[\nhello]=]", &expected);
+    check(b"[=[\rhello]=]", &expected);
+    check(b"[=[\r\nhello]=]", &expected);
+    check(b"[=[\n\rhello]=]", &expected);
+
     // Any whitespace characters after the initial newline are included
     let expected = LuaValue::String(b" hello".into());
     check(b"[[\n hello]]", &expected);
@@ -124,11 +129,21 @@ fn long_string() {
     check(b"[[\r\n hello]]", &expected);
     check(b"[[\n\r hello]]", &expected);
 
-    // Only one of the newlines is removed.
+    check(b"[=[\n hello]=]", &expected);
+    check(b"[=[\r hello]=]", &expected);
+    check(b"[=[\r\n hello]=]", &expected);
+    check(b"[=[\n\r hello]=]", &expected);
+
+    // Only the first newline is removed.
     check(b"[[\n\nhello]]", LuaValue::String(b"\nhello".into()));
     check(b"[[\r\rhello]]", LuaValue::String(b"\rhello".into()));
     check(b"[[\r\n\r\nhello]]", LuaValue::String(b"\r\nhello".into()));
     check(b"[[\n\r\n\rhello]]", LuaValue::String(b"\n\rhello".into()));
+
+    check(b"[=[\n\nhello]=]", LuaValue::String(b"\nhello".into()));
+    check(b"[=[\r\rhello]=]", LuaValue::String(b"\rhello".into()));
+    check(b"[=[\r\n\r\nhello]=]", LuaValue::String(b"\r\nhello".into()));
+    check(b"[=[\n\r\n\rhello]=]", LuaValue::String(b"\n\rhello".into()));
 
     // Multiple types of brackets in the same value
     check(

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -157,7 +157,6 @@ fn newlines() {
         LuaValue::String(b"hello\n\rworld".into()),
     );
 
-
     // When the opening long bracket is immediately followed by a newline, the newline is not
     // included in the string.
     let expected = LuaValue::String(b"hello".into());
@@ -191,19 +190,37 @@ fn newlines() {
 
     check(b"[=[\n\nhello]=]", LuaValue::String(b"\nhello".into()));
     check(b"[=[\r\rhello]=]", LuaValue::String(b"\rhello".into()));
-    check(b"[=[\r\n\r\nhello]=]", LuaValue::String(b"\r\nhello".into()));
-    check(b"[=[\n\r\n\rhello]=]", LuaValue::String(b"\n\rhello".into()));
+    check(
+        b"[=[\r\n\r\nhello]=]",
+        LuaValue::String(b"\r\nhello".into()),
+    );
+    check(
+        b"[=[\n\r\n\rhello]=]",
+        LuaValue::String(b"\n\rhello".into()),
+    );
 
     // Trailing newlines are retained.
     check(b"[[\n\nhello\n]]", LuaValue::String(b"\nhello\n".into()));
     check(b"[[\r\rhello\r]]", LuaValue::String(b"\rhello\r".into()));
-    check(b"[[\r\n\r\nhello\r\n]]", LuaValue::String(b"\r\nhello\r\n".into()));
-    check(b"[[\n\r\n\rhello\n\r]]", LuaValue::String(b"\n\rhello\n\r".into()));
+    check(
+        b"[[\r\n\r\nhello\r\n]]",
+        LuaValue::String(b"\r\nhello\r\n".into()),
+    );
+    check(
+        b"[[\n\r\n\rhello\n\r]]",
+        LuaValue::String(b"\n\rhello\n\r".into()),
+    );
 
     check(b"[=[\n\nhello\n]=]", LuaValue::String(b"\nhello\n".into()));
     check(b"[=[\r\rhello\r]=]", LuaValue::String(b"\rhello\r".into()));
-    check(b"[=[\r\n\r\nhello\r\n]=]", LuaValue::String(b"\r\nhello\r\n".into()));
-    check(b"[=[\n\r\n\rhello\n\r]=]", LuaValue::String(b"\n\rhello\n\r".into()));
+    check(
+        b"[=[\r\n\r\nhello\r\n]=]",
+        LuaValue::String(b"\r\nhello\r\n".into()),
+    );
+    check(
+        b"[=[\n\r\n\rhello\n\r]=]",
+        LuaValue::String(b"\n\rhello\n\r".into()),
+    );
 }
 
 #[test]

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -109,6 +109,27 @@ fn long_string() {
         LuaValue::String(b"hell[[o]] w[=[o]=]rld".into()),
     );
 
+    // When the opening long bracket is immediately followed by a newline, the newline is not
+    // included in the string.
+    let expected = LuaValue::String(b"hello".into());
+    check(b"[[\nhello]]", &expected);
+    check(b"[[\rhello]]", &expected);
+    check(b"[[\r\nhello]]", &expected);
+    check(b"[[\n\rhello]]", &expected);
+
+    // Any whitespace characters after the initial newline are included
+    let expected = LuaValue::String(b" hello".into());
+    check(b"[[\n hello]]", &expected);
+    check(b"[[\r hello]]", &expected);
+    check(b"[[\r\n hello]]", &expected);
+    check(b"[[\n\r hello]]", &expected);
+
+    // Only one of the newlines is removed.
+    check(b"[[\n\nhello]]", LuaValue::String(b"\nhello".into()));
+    check(b"[[\r\rhello]]", LuaValue::String(b"\rhello".into()));
+    check(b"[[\r\n\r\nhello]]", LuaValue::String(b"\r\nhello".into()));
+    check(b"[[\n\r\n\rhello]]", LuaValue::String(b"\n\rhello".into()));
+
     // Multiple types of brackets in the same value
     check(
         b"{[[hello]],[=[world]=],'!',\"?\"}",


### PR DESCRIPTION
This fixes two issues with string parsing:

* If a long string starts with a newline, it should be removed, ie:

  ```lua
  "hello" == [[
  hello]]
  ```

* Fix a parser precedence issue where `\n\r` newlines could not be escaped in short strings.