### PR TITLE
Add basic WASM support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,31 @@ jobs:
 
       - run: cargo test
       - run: cargo test --no-default-features
+
+  wasm:
+    name: Rust ${{matrix.rust_version}} (WASM)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust_version: [stable, 1.85.0]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - run: cargo check --target wasm32-unknown-unknown
+      - run: cargo check --no-default-features --target wasm32-unknown-unknown
+
+      - run: cargo clippy --no-deps --workspace --target wasm32-unknown-unknown
+      - run: cargo clippy --no-deps --workspace --no-default-features --target wasm32-unknown-unknown
+
+      - run: cargo build --target wasm32-unknown-unknown
+      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --headless --firefox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Thank you for your interest in contributing to this project!
 
 ## Scope
 
+### Lua
+
 This library targets compatibility with Lua 5.4 (the current stable version, at the time of writing)
 and data structures that have JSON equivalents (eg: `table` is like `Array` or `Object`).
 
@@ -12,17 +14,25 @@ that they don't break compatibility with Lua 5.4. Aside from identifier restrict
 subtype and float coercion changes (in Lua 5.2, 5.3 and 5.4 respectively), I don't expect this to be
 a big issue.
 
-Executing arbitrary code is explicitly out of scope. _Try [`mlua`][mlua] instead!_
+Executing arbitrary code and Luau language features are explicitly out of scope.
+_Try [`mlua`][mlua] instead!_
 
-On the Rust side, this project targets the current stable version of Rust on
-[64-bit platforms with Tier 1 with Host Tools][rust-tier]. Support for stable versions up to 1 year
-old is on a "best effort" basis, and support for other platforms is on a "if you do the work, it's
-simple and testable in CI" basis.
+### Rust
+
+This project targets the current stable version of Rust on
+[64-bit platforms with Tier 1 with Host Tools][rust-tier] and [WASM][rust-wasm].
+
+Support for stable versions up to 1 year old is on a "best effort" basis, and support for other
+platforms is on a "if you do the work, it's simple and testable in CI" basis.
+
+### Parser
 
 This library is built around [a PEG parser][peg-parser] to simplify things, so needs to be able to
-keep your entire Lua script in memory. It will avoid copying data where possible, but there are
-cases where this is unavoidable. Generally speaking, this should result in memory usage that is
-_not significantly worse_ than evaluating the source code with Lua.
+keep your entire Lua script in memory. It will avoid making copies of that script where possible,
+but there are cases where this is unavoidable.
+
+Ideally this should result in memory usage that is _not significantly worse_ than evaluating the
+source code with Lua... but this is not currently measured.
 
 ## Submitting issues
 
@@ -75,3 +85,4 @@ Examples of welcomed contributions:
 [serde-help]: https://serde.rs/help.html
 [rust-tier]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 [security]: https://github.com/micolous/serde_luaq/security
+[wasm]: https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-unknown-unknown.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,10 +199,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -169,10 +240,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "peg"
@@ -220,10 +316,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -279,7 +390,15 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"
@@ -329,6 +448,125 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e90e66d265d3a1efc0e72a54809ab90b9c0c515915c67cdf658689d2c22c6c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7150335716dce6028bead2b848e72f47b45e7b9422f64cccdc23bedca89affc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,17 @@ serde = "1.0.210"
 serde_json = { version = "1.0.138", optional = true }
 thiserror = "1.0.63"
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+wasm-bindgen = "0.2"
+
 [dev-dependencies]
 flate2 = "1.1.2"
 serde = { version = "1.0.194", features = ["derive"] }
 serde_bytes = "0.11.17"
 serde_derive = "1.0.166"
+
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [[example]]
 name = "balatro_to_json"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ that a JSON parser would implement:
   - [x] [Floats][lua3.1]
     - [x] Decimal floats with decimal point and optional exponent (`3.14`, `0.314e1`)
     - [x] Decimal floats with mandatory exponent (`3e14`)
-    - [x] Hexadecimal floating points (`0x.ABCDEFp+24`)
+    - [x] Hexadecimal floating points (`0x.ABCDEFp+24`) (*not supported on WASM*)
     - [x] Positive and negative infinity (`1e9999`, `-1e9999`)
     - [x] NaN (`(0/0)`)
 - [x] [Strings][lua3.1]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ mod serde_json;
 mod table_entry;
 mod value;
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::ffi::CString;
 
 pub use crate::{
@@ -174,6 +175,7 @@ fn valid_lua_identifier(i: &[u8]) -> bool {
     i.all(|&c| c.is_ascii_alphanumeric() || c == b'_')
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 /// Converts a string to a `f64` using C's standard library.
 ///
 /// This supports parsing hexadecimal floating points.

--- a/src/number.rs
+++ b/src/number.rs
@@ -182,7 +182,13 @@ impl Display for LuaNumber {
 mod test {
     use super::*;
 
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_integer() {
         // i64
         assert_eq!(LuaNumber::Integer(0), LuaNumber::from(0));
@@ -240,6 +246,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn to_integer() {
         assert_eq!(0_i64, LuaNumber::Integer(0).as_i64().unwrap());
         assert_eq!(i64::MIN, LuaNumber::Integer(i64::MIN).as_i64().unwrap());
@@ -253,6 +260,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_float() {
         // f64
         assert_eq!(LuaNumber::Float(0.), LuaNumber::from(0.));
@@ -289,6 +297,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn to_float() {
         assert_eq!(0_f64, LuaNumber::Float(0.).as_f64().unwrap());
         assert_eq!(-0_f64, LuaNumber::Float(-0.).as_f64().unwrap());

--- a/src/value.rs
+++ b/src/value.rs
@@ -49,6 +49,9 @@ pub enum LuaValue<'a> {
     /// Number type, which can be an [integer][LuaNumber::Integer] or
     /// [floating point][LuaNumber::Float].
     ///
+    /// **Note:** hexadecimal floating point literals are not supported by `serde_luaq` when running
+    /// on WASM targets, because it requires a `strtod()` implementation.
+    ///
     /// ## Compatibility
     ///
     /// * **Lua 5.2 and earlier, and Luau** always use `f64` for numbers.
@@ -489,6 +492,11 @@ mod test {
     use super::*;
     use std::{cmp::PartialEq, fmt::Debug};
 
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
     fn assert_cow_eq<'a, T, U>(expected: U, is_borrowed: bool, actual: Cow<'a, T>)
     where
         T: ToOwned + Debug + ?Sized,
@@ -501,6 +509,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn cow() {
         assert_cow_eq("foo", true, from_utf8_cow(b"foo".into()).unwrap());
         assert_cow_eq("foo", true, from_utf8_cow_lossy(b"foo".into()));
@@ -518,6 +527,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_bool_option() {
         // bool
         assert_eq!(LuaValue::Boolean(true), LuaValue::from(true));
@@ -530,6 +540,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_integer() {
         // i64
         assert_eq!(LuaValue::integer(0), LuaValue::from(0));
@@ -569,6 +580,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_float() {
         // f64
         assert_eq!(LuaValue::float(0.), LuaValue::from(0.));

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -3,13 +3,20 @@ use serde_luaq::LuaValue;
 
 use crate::common::check;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn booleans() {
     check(b"true", LuaValue::Boolean(true));
     check(b"false", LuaValue::Boolean(false));
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn nil() {
     check(b"nil", LuaValue::Nil);
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -4,10 +4,16 @@ use serde::Deserialize;
 use serde_luaq::{from_slice, LuaFormat};
 use std::collections::BTreeMap;
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 /// Deserialise a simple `struct`
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn struct_simple() {
     #[derive(Deserialize, PartialEq, Debug)]
     struct Test {
@@ -47,6 +53,7 @@ fn struct_simple() {
 
 /// Deserialise a struct with a [`BTreeMap`] field
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn btreemap_field() {
     #[derive(Deserialize, PartialEq, Debug)]
     struct Test {
@@ -65,6 +72,7 @@ fn btreemap_field() {
 
 /// Deseralise a [`BTreeMap`] directly
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn btreemap_bare() {
     let lua_return = br#"return {[1]="hello",[2]="goodbye"}"#;
     let lua_value = br#"{[1]="hello",[2]="goodbye"}"#;
@@ -81,6 +89,7 @@ fn btreemap_bare() {
 
 /// Deserialise a [`BTreeMap`] with an `enum` key
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn btreemap_enum_keys() {
     #[derive(Deserialize, PartialEq, Debug, PartialOrd, Eq, Ord)]
     enum Enum {
@@ -105,6 +114,7 @@ fn btreemap_enum_keys() {
 
 /// Deseraliase an `enum` with multiple variants.
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn enum_variants() {
     #[derive(Deserialize, PartialEq, Debug)]
     enum E {
@@ -147,6 +157,7 @@ fn enum_variants() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn integers() {
     #[derive(Deserialize, PartialEq, Debug)]
     struct Integers {
@@ -225,6 +236,7 @@ fn integers() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn booleans() -> Result {
     #[derive(Deserialize, PartialEq, Debug)]
     struct Booleans {
@@ -306,6 +318,7 @@ fn booleans() -> Result {
 
 /// Tests for Serde's field naming
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn field_naming() -> Result {
     #[derive(Deserialize, PartialEq, Debug)]
     struct FieldNaming {
@@ -422,6 +435,7 @@ fn strings() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arrays() -> Result {
     let expected = ("hello", "world");
     assert_eq!(

--- a/tests/identifiers.rs
+++ b/tests/identifiers.rs
@@ -1,8 +1,14 @@
 use serde_luaq::{lua_value, return_statement, script, LuaTableEntry, LuaValue};
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn keywords() -> Result {
     // Assignment to keyword is invalid.
     assert!(script(b"and = true\n").is_err());
@@ -235,6 +241,7 @@ fn keywords() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn contains_keyword() -> Result {
     // Starts with a keyword
     assert_eq!(
@@ -599,6 +606,7 @@ fn contains_keyword() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn invalid() {
     // Starts with a number
     assert!(script(b"1a = true\n").is_err());

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -5,12 +5,18 @@ use serde_luaq::{
     LuaTableEntry, LuaValue,
 };
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 const DEFAULT_OPTS: JsonConversionOptions = JsonConversionOptions {
     lossy_string: false,
 };
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn table_precedence() -> Result {
     // The last table entry takes precedence
     let expected = json!({"1": 2, "2": 4});
@@ -37,6 +43,7 @@ fn table_precedence() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn table_coersion() -> Result {
     assert_eq!(
         json!([1, 2, 3, 4]),
@@ -140,6 +147,7 @@ fn table_coersion() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn disallowed_floats() -> Result {
     // JSON doesn't allow NaN, +Inf or -Inf
     assert_eq!(
@@ -161,7 +169,9 @@ fn disallowed_floats() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn floats() -> Result {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     assert_eq!(
         json!(2.3125),
         to_json_value(lua_value(b"0x2.5")?, &DEFAULT_OPTS)?
@@ -190,6 +200,7 @@ fn floats() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn ints() -> Result {
     assert_eq!(json!(2), to_json_value(lua_value(b"0x2")?, &DEFAULT_OPTS)?);
     assert_eq!(

--- a/tests/numerals.rs
+++ b/tests/numerals.rs
@@ -2,10 +2,18 @@
 mod common;
 
 use crate::common::check;
-use serde_luaq::{lua_value, LuaValue};
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use serde_luaq::lua_value;
+use serde_luaq::LuaValue;
+
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
 
 /// Decimal integer values
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn decimal_integers() {
     // https://www.lua.org/manual/5.4/manual.html#3.1
     check(b"0", LuaValue::integer(0));
@@ -42,6 +50,7 @@ fn decimal_integers() {
 
 /// Hex integer values
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn hex_integers() {
     check(b"0xff", LuaValue::integer(0xff));
     check(b"0Xff", LuaValue::integer(0xff));
@@ -103,6 +112,7 @@ fn hex_integers() {
 
 /// Decimal floats
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn decimal_floats() {
     check(b"0.0", LuaValue::float(0.0));
     check(b"-0.0", LuaValue::float(-0.0));
@@ -121,6 +131,7 @@ fn decimal_floats() {
     check(b"-34e1", LuaValue::float(-34e1));
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 /// Hex floats
 #[test]
 fn hex_floats() {
@@ -151,6 +162,7 @@ fn hex_floats() {
 
 /// Special floats
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn special_floats() {
     check(b"(0/0)", LuaValue::float(f64::NAN));
     check(b"1e9999", LuaValue::float(f64::INFINITY));

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -4,9 +4,15 @@ mod common;
 use crate::common::check;
 use serde_luaq::{lua_value, LuaTableEntry, LuaValue};
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn basics() {
     // Empty string
     check(b"\"\"", LuaValue::String(b"".into()));
@@ -17,6 +23,7 @@ fn basics() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn long_string() {
     check(b"[[]]", LuaValue::String(b"".into()));
     check(b"[=[]=]", LuaValue::String(b"".into()));
@@ -122,6 +129,7 @@ fn long_string() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn newlines() {
     // Short strings need to escape newlines
     assert!(lua_value(b"'\nfoo'").is_err());
@@ -224,6 +232,7 @@ fn newlines() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn escapes() {
     // https://github.com/lua/tests/blob/26eebb47b6442996d89e298b99404cbf53468c4c/strings.lua#L152
     check(
@@ -265,6 +274,7 @@ fn escapes() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn unicode_escapes() {
     check(br"'\u{80}'", LuaValue::String(b"\xC2\x80".into()));
     check(
@@ -328,6 +338,7 @@ fn unicode_escapes() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn invalid_escapes() {
     assert!(lua_value(br"'\256'").is_err());
     assert!(lua_value(br"'\c'").is_err());
@@ -339,6 +350,7 @@ fn invalid_escapes() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn borrows() -> Result {
     // Empty strings
     assert!(lua_value(b"[[]]")?.is_borrowed());

--- a/tests/tables.rs
+++ b/tests/tables.rs
@@ -3,9 +3,15 @@ mod common;
 use crate::common::check;
 use serde_luaq::{lua_value, script, LuaTableEntry, LuaValue};
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn simple_table() -> Result {
     let data =
         br#"{["int"]=1,["seq"]={"a", "b", x3yz = 0x12, ["foo"] = "bar", [5] = 42, [0xa] = 3.14}}"#;
@@ -78,6 +84,7 @@ fn simple_table() -> Result {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn tables() {
     // Empty object
     let b = b"{}";

--- a/tests/unsupported.rs
+++ b/tests/unsupported.rs
@@ -4,89 +4,109 @@ mod common;
 use crate::common::should_error;
 use serde_luaq::{lua_value, return_statement, script, LuaValue};
 
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_add() {
     should_error(b"3 + 2\n");
     should_error(b"3+2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_sub() {
     should_error(b"3 - 2\n");
     should_error(b"3-2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_mul() {
     should_error(b"3 * 2\n");
     should_error(b"3*2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_div() {
     should_error(b"3 / 2\n");
     should_error(b"3/2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_fdiv() {
     should_error(b"3 // 2\n");
     should_error(b"3//2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_mod() {
     should_error(b"3 % 2\n");
     should_error(b"3%2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arithmetic_exp() {
     should_error(b"3 ^ 2\n");
     should_error(b"3^2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn bitwise_and() {
     should_error(b"3 & 2\n");
     should_error(b"3&2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn bitwise_or() {
     should_error(b"3 | 4\n");
     should_error(b"3|4\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn bitwise_xor() {
     should_error(b"3 ~ 2\n");
     should_error(b"3~2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn bitwise_shl() {
     should_error(b"3 << 2\n");
     should_error(b"3<<2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn bitwise_shr() {
     should_error(b"3 >> 2\n");
     should_error(b"3>>2\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn bitwise_not() {
     should_error(b"~3\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn block_do() {
     assert!(script(b"a = 3\ndo\n  a = 4\nend\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn coroutine() {
     should_error(
         b"coroutine.create(function (a)\n  coroutine.yield(a + 2)\n  return a + 10\nend)\n",
@@ -94,6 +114,7 @@ fn coroutine() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn functions() {
     assert!(script(b"function a()\n  return 3\nend\nb = a()\n").is_err());
     assert!(script(b"function a()\n  return 3\nend\nb=a()\n").is_err());
@@ -108,83 +129,98 @@ fn functions() {
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn length_operator() {
     assert!(script(b"a = [1, 2, 3]\nb = #a\n").is_err());
     assert!(script(b"a=[1,2,3]\nb=#a\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn local() {
     assert!(script(b"local a = 3\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn logical_and() {
     should_error(b"true and true\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn logical_or() {
     should_error(b"true or false\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn logical_not() {
     should_error(b"b = not false\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn parentheses() {
     should_error(b"(3)\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn referencing() {
     assert!(script(b"a = 3\nb = a\n").is_err());
     assert!(script(b"a = {}\na.b = 3\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_eq() {
     assert!(script(b"a = 3\nb = a == 3\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_neq() {
     assert!(script(b"a = 3\nb = a ~= 1\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_lt() {
     assert!(script(b"a = 3\nb = a < 1\n").is_err());
     assert!(script(b"a = 3\nb=a<1\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_lte() {
     assert!(script(b"a = 3\nb = a <= 1\n").is_err());
     assert!(script(b"a = 3\nb=a<=1\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_gt() {
     assert!(script(b"a = 3\nb = a > 1\n").is_err());
     assert!(script(b"a = 3\nb=a>1\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_gte() {
     assert!(script(b"a = 3\nb = a >= 1\n").is_err());
     assert!(script(b"a = 3\nb=a>=1\n").is_err());
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn string_concat() {
     should_error(b"'hello' .. 'world'\n");
     should_error(b"'hello'..'world'\n");
 }
 
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn vararg_assignments() {
     assert!(script(b"a, b = 'hello', 'world'\n").is_err());
     assert!(script(b"a,b='hello','world'\n").is_err());


### PR DESCRIPTION
This allows `serde_luaq` to run on WASM targets.

Unfortunately, `strtod` isn't available there, so we need to drop parsing hex floats.

## TODO

* [x] get this running in CI