### PR TITLE
Implement recursion limits

### DIFF
--- a/examples/balatro_to_json.rs
+++ b/examples/balatro_to_json.rs
@@ -53,7 +53,7 @@ fn main() -> Result {
     let mut buf = Vec::with_capacity(SIZE_LIMIT);
     f.read_to_end(&mut buf)?;
 
-    let map = to_json_value(return_statement(&buf)?, &Default::default())?;
+    let map = to_json_value(return_statement(&buf, 16)?, &Default::default())?;
 
     let mut f: Box<dyn Write> = if let Some(output) = args.output {
         Box::new(BufWriter::new(

--- a/examples/lua_to_json.rs
+++ b/examples/lua_to_json.rs
@@ -52,7 +52,7 @@ struct Args {
     /// Maximum Lua file size to process
     #[arg(long, default_value_t = DEFAULT_SIZE_LIMIT, id = "BYTES")]
     lua_size_limit: usize,
-    
+
     /// Maximum object depth
     #[arg(long, default_value_t = DEFAULT_MAX_DEPTH, id = "DEPTH")]
     max_depth: usize,

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -32,7 +32,7 @@ struct Car {
 fn main() -> Result<()> {
     let car: Car = from_slice(br#"
         {active = true, model = "Volkswagen Golf", transmission = "Automatic", engine = {v = 1499, kw = 90}}
-    "#, LuaFormat::Value)?;
+    "#, LuaFormat::Value, 5)?;
 
     println!("Car: {car:?}");
 
@@ -42,6 +42,7 @@ fn main() -> Result<()> {
         br#"
         {driver = "Boris", price = nil}
     "#,
+        5,
     )?;
 
     println!("Val: {val:?}");

--- a/src/de.rs
+++ b/src/de.rs
@@ -887,14 +887,14 @@ pub enum LuaFormat {
 ///
 /// When matching Lua table keys to Rust identifiers, table keys must be encoded
 /// as valid UTF-8.
-pub fn from_slice<'a, T>(b: &'a [u8], format: LuaFormat) -> Result<T, Error>
+pub fn from_slice<'a, T>(b: &'a [u8], format: LuaFormat, max_depth: usize) -> Result<T, Error>
 where
     T: de::Deserialize<'a>,
 {
     let v = match format {
-        LuaFormat::Value => lua_value(b)?,
-        LuaFormat::Script => script(b)?.into_iter().collect(),
-        LuaFormat::Return => return_statement(b)?,
+        LuaFormat::Value => lua_value(b, max_depth)?,
+        LuaFormat::Script => script(b, max_depth)?.into_iter().collect(),
+        LuaFormat::Return => return_statement(b, max_depth)?,
     };
 
     Deserialize::deserialize(v)
@@ -911,9 +911,9 @@ where
 ///
 /// This method assumes that a Lua expression is encoded as valid UTF-8.
 #[inline]
-pub fn from_str<'a, T>(b: &'a str, format: LuaFormat) -> Result<T, Error>
+pub fn from_str<'a, T>(b: &'a str, format: LuaFormat, max_depth: usize) -> Result<T, Error>
 where
     T: de::Deserialize<'a>,
 {
-    from_slice(b.as_bytes(), format)
+    from_slice(b.as_bytes(), format, max_depth)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ```rust
 //! use serde_luaq::{LuaValue, lua_value};
-//! assert_eq!(LuaValue::Boolean(true), lua_value(b"true").unwrap());
+//! assert_eq!(LuaValue::Boolean(true), lua_value(b"true", /* max table depth */ 16).unwrap());
 //! ```
 //!
 //! There are similar deserialisers for [a single `return` statement][return_statement] and
@@ -62,6 +62,7 @@
 //!     from_slice(
 //!         b"{a=true, [[[b]]]={[3] = 3, 0x1, 2}, ['c'] = { foo = \"bar\" }}",
 //!         LuaFormat::Value,
+//!         /* maximum table depth */ 16,
 //!     ).unwrap(),
 //! );
 //! ```

--- a/src/peg_parser.rs
+++ b/src/peg_parser.rs
@@ -484,7 +484,7 @@ peg::parser! {
             }
 
         rule table(max_depth: usize) -> Vec<LuaTableEntry<'input>>
-            = 
+            =
                 ("{" {?
                     if max_depth == 0 {
                         Err("too deeply nested")

--- a/src/peg_parser.rs
+++ b/src/peg_parser.rs
@@ -488,6 +488,8 @@ peg::parser! {
         rule table(max_depth: usize) -> Vec<LuaTableEntry<'input>>
             =
                 ("{" {?
+                    // rust-peg doesn't have a stack limit; workaround based on
+                    // https://github.com/kevinmehall/rust-peg/issues/282#issuecomment-2169784035
                     if max_depth == 0 {
                         Err("too deeply nested")
                     } else {

--- a/src/peg_parser.rs
+++ b/src/peg_parser.rs
@@ -432,11 +432,13 @@ peg::parser! {
         /// ```rust
         /// use serde_luaq::{lua_value, LuaValue};
         ///
-        /// assert_eq!(LuaValue::Boolean(true), lua_value(b"true").unwrap());
-        /// assert_eq!(LuaValue::Boolean(false), lua_value(b"  false\r\n  ").unwrap());
+        /// assert_eq!(LuaValue::Boolean(true), lua_value(b"true", 16).unwrap());
+        /// assert_eq!(LuaValue::Boolean(false), lua_value(b"  false\r\n  ", 16).unwrap());
         /// ```
         ///
         /// For more information about Lua type conversion, see [`LuaValue`].
+        ///
+        /// `max_depth` defines the maximum recursion depth for tables.
         pub rule lua_value(max_depth: usize) -> LuaValue<'input>
             = (
                 _ "nil" _ { LuaValue::Nil } /
@@ -511,11 +513,14 @@ peg::parser! {
         ///         ("hello", LuaValue::Boolean(true)),
         ///         ("goodbye", LuaValue::Boolean(false)),
         ///     ],
-        ///     script(b"hello = true\ngoodbye = false").unwrap()
+        ///     script(b"hello = true\ngoodbye = false", 16).unwrap()
         /// );
         /// ```
         ///
         /// For more information about Lua type conversion, see [`LuaValue`].
+        ///
+        /// `max_depth` defines the maximum recursion depth for tables.
+
         pub rule script(max_depth: usize) -> Vec<(&'input str, LuaValue<'input>)>
             = (_ a:assignment(max_depth) _ (";" _)* { a })*
 
@@ -524,10 +529,12 @@ peg::parser! {
         /// ```rust
         /// use serde_luaq::{return_statement, LuaValue};
         ///
-        /// assert_eq!(LuaValue::Boolean(true), return_statement(b"return true\n").unwrap());
+        /// assert_eq!(LuaValue::Boolean(true), return_statement(b"return true\n", 16).unwrap());
         /// ```
         ///
         /// For more information about Lua type conversion, see [`LuaValue`].
+        ///
+        /// `max_depth` defines the maximum recursion depth for tables.
         pub rule return_statement(max_depth: usize) -> LuaValue<'input>
             = _ "return" __ v:lua_value(max_depth) _ { v }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,13 +2,14 @@
 #![allow(dead_code)]
 
 use std::borrow::Borrow;
-
 use serde_luaq::{lua_value, return_statement, script, LuaValue};
+
+pub const MAX_DEPTH: usize = 16;
 
 /// Parse a buffer of Lua code and expect no remaining value.
 pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
     let expected: &LuaValue<'a> = expected.borrow();
-    let actual = lua_value(lua).unwrap();
+    let actual = lua_value(lua, MAX_DEPTH).unwrap();
 
     if expected.is_nan() {
         assert!(actual.is_nan(), "lua: {}", lua.escape_ascii());
@@ -20,7 +21,7 @@ pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
     s.extend_from_slice(b"a = ");
     s.extend_from_slice(lua);
 
-    let (n, actual) = script(&s).unwrap().pop().unwrap();
+    let (n, actual) = script(&s, MAX_DEPTH).unwrap().pop().unwrap();
     assert_eq!("a", n);
 
     if expected.is_nan() {
@@ -31,13 +32,13 @@ pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
 }
 
 pub fn should_error(lua: &'_ [u8]) {
-    assert!(lua_value(lua).is_err(), "lua value: {}", lua.escape_ascii());
+    assert!(lua_value(lua, MAX_DEPTH).is_err(), "lua value: {}", lua.escape_ascii());
 
     let mut r = Vec::with_capacity(lua.len() + 7);
     r.extend_from_slice(b"return ");
     r.extend_from_slice(lua);
     assert!(
-        return_statement(lua).is_err(),
+        return_statement(lua, MAX_DEPTH).is_err(),
         "lua return: {}",
         lua.escape_ascii()
     );
@@ -46,5 +47,5 @@ pub fn should_error(lua: &'_ [u8]) {
     s.extend_from_slice(b"a = ");
     s.extend_from_slice(lua);
 
-    assert!(script(lua).is_err(), "lua script: {}", lua.escape_ascii());
+    assert!(script(lua, MAX_DEPTH).is_err(), "lua script: {}", lua.escape_ascii());
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,8 @@
 //! Tests with Lua literals
 #![allow(dead_code)]
 
-use std::borrow::Borrow;
 use serde_luaq::{lua_value, return_statement, script, LuaValue};
+use std::borrow::Borrow;
 
 pub const MAX_DEPTH: usize = 16;
 
@@ -32,7 +32,11 @@ pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
 }
 
 pub fn should_error(lua: &'_ [u8]) {
-    assert!(lua_value(lua, MAX_DEPTH).is_err(), "lua value: {}", lua.escape_ascii());
+    assert!(
+        lua_value(lua, MAX_DEPTH).is_err(),
+        "lua value: {}",
+        lua.escape_ascii()
+    );
 
     let mut r = Vec::with_capacity(lua.len() + 7);
     r.extend_from_slice(b"return ");
@@ -47,5 +51,9 @@ pub fn should_error(lua: &'_ [u8]) {
     s.extend_from_slice(b"a = ");
     s.extend_from_slice(lua);
 
-    assert!(script(lua, MAX_DEPTH).is_err(), "lua script: {}", lua.escape_ascii());
+    assert!(
+        script(lua, MAX_DEPTH).is_err(),
+        "lua script: {}",
+        lua.escape_ascii()
+    );
 }

--- a/tests/identifiers.rs
+++ b/tests/identifiers.rs
@@ -1,3 +1,6 @@
+mod common;
+use crate::common::MAX_DEPTH;
+
 use serde_luaq::{lua_value, return_statement, script, LuaTableEntry, LuaValue};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -11,75 +14,75 @@ type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn keywords() -> Result {
     // Assignment to keyword is invalid.
-    assert!(script(b"and = true\n").is_err());
-    assert!(script(b"break = true\n").is_err());
-    assert!(script(b"do = true\n").is_err());
-    assert!(script(b"else = true\n").is_err());
-    assert!(script(b"elseif = true\n").is_err());
-    assert!(script(b"end = true\n").is_err());
-    assert!(script(b"false = true\n").is_err());
-    assert!(script(b"for = true\n").is_err());
-    assert!(script(b"function = true\n").is_err());
-    assert!(script(b"goto = true\n").is_err());
-    assert!(script(b"if = true\n").is_err());
-    assert!(script(b"in = true\n").is_err());
-    assert!(script(b"local = true\n").is_err());
-    assert!(script(b"nil = true\n").is_err());
-    assert!(script(b"not = true\n").is_err());
-    assert!(script(b"or = true\n").is_err());
-    assert!(script(b"repeat = true\n").is_err());
-    assert!(script(b"return = true\n").is_err());
-    assert!(script(b"then = true\n").is_err());
-    assert!(script(b"true = true\n").is_err());
-    assert!(script(b"until = true\n").is_err());
-    assert!(script(b"while = true\n").is_err());
+    assert!(script(b"and = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"break = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"do = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"else = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"elseif = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"end = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"false = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"for = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"function = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"goto = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"if = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"in = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"local = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"nil = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"not = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"or = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"repeat = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"return = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"then = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"true = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"until = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"while = true\n", MAX_DEPTH).is_err());
 
     // Keywords used as identifier in table keys is invalid.
-    assert!(return_statement(b"return {and = true}").is_err());
-    assert!(return_statement(b"return {break = true}").is_err());
-    assert!(return_statement(b"return {do = true}").is_err());
-    assert!(return_statement(b"return {else = true}").is_err());
-    assert!(return_statement(b"return {elseif = true}").is_err());
-    assert!(return_statement(b"return {end = true}").is_err());
-    assert!(return_statement(b"return {false = true}").is_err());
-    assert!(return_statement(b"return {for = true}").is_err());
-    assert!(return_statement(b"return {function = true}").is_err());
-    assert!(return_statement(b"return {goto = true}").is_err());
-    assert!(return_statement(b"return {if = true}").is_err());
-    assert!(return_statement(b"return {in = true}").is_err());
-    assert!(return_statement(b"return {local = true}").is_err());
-    assert!(return_statement(b"return {nil = true}").is_err());
-    assert!(return_statement(b"return {not = true}").is_err());
-    assert!(return_statement(b"return {or = true}").is_err());
-    assert!(return_statement(b"return {repeat = true}").is_err());
-    assert!(return_statement(b"return {return = true}").is_err());
-    assert!(return_statement(b"return {then = true}").is_err());
-    assert!(return_statement(b"return {true = true}").is_err());
-    assert!(return_statement(b"return {until = true}").is_err());
-    assert!(return_statement(b"return {while = true}").is_err());
+    assert!(return_statement(b"return {and = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {break = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {do = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {else = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {elseif = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {end = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {false = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {for = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {function = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {goto = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {if = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {in = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {local = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {nil = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {not = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {or = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {repeat = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {return = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {then = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {true = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {until = true}", MAX_DEPTH).is_err());
+    assert!(return_statement(b"return {while = true}", MAX_DEPTH).is_err());
 
-    assert!(lua_value(b"{and = true}").is_err());
-    assert!(lua_value(b"{break = true}").is_err());
-    assert!(lua_value(b"{do = true}").is_err());
-    assert!(lua_value(b"{else = true}").is_err());
-    assert!(lua_value(b"{elseif = true}").is_err());
-    assert!(lua_value(b"{end = true}").is_err());
-    assert!(lua_value(b"{false = true}").is_err());
-    assert!(lua_value(b"{for = true}").is_err());
-    assert!(lua_value(b"{function = true}").is_err());
-    assert!(lua_value(b"{goto = true}").is_err());
-    assert!(lua_value(b"{if = true}").is_err());
-    assert!(lua_value(b"{in = true}").is_err());
-    assert!(lua_value(b"{local = true}").is_err());
-    assert!(lua_value(b"{nil = true}").is_err());
-    assert!(lua_value(b"{not = true}").is_err());
-    assert!(lua_value(b"{or = true}").is_err());
-    assert!(lua_value(b"{repeat = true}").is_err());
-    assert!(lua_value(b"{return = true}").is_err());
-    assert!(lua_value(b"{then = true}").is_err());
-    assert!(lua_value(b"{true = true}").is_err());
-    assert!(lua_value(b"{until = true}").is_err());
-    assert!(lua_value(b"{while = true}").is_err());
+    assert!(lua_value(b"{and = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{break = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{do = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{else = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{elseif = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{end = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{false = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{for = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{function = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{goto = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{if = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{in = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{local = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{nil = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{not = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{or = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{repeat = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{return = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{then = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{true = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{until = true}", MAX_DEPTH).is_err());
+    assert!(lua_value(b"{while = true}", MAX_DEPTH).is_err());
 
     // Keywords used as table key in strings should be accepted.
     assert_eq!(
@@ -87,154 +90,154 @@ fn keywords() -> Result {
             b"and".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"and\"] = true}")?,
+        lua_value(b"{[\"and\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"break".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"break\"] = true}")?,
+        lua_value(b"{[\"break\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"do".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"do\"] = true}")?,
+        lua_value(b"{[\"do\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"else".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"else\"] = true}")?,
+        lua_value(b"{[\"else\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"elseif".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"elseif\"] = true}")?,
+        lua_value(b"{[\"elseif\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"end".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"end\"] = true}")?,
+        lua_value(b"{[\"end\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"false".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"false\"] = true}")?,
+        lua_value(b"{[\"false\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"for".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"for\"] = true}")?,
+        lua_value(b"{[\"for\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"function".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"function\"] = true}")?,
+        lua_value(b"{[\"function\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"goto".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"goto\"] = true}")?,
+        lua_value(b"{[\"goto\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"if".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"if\"] = true}")?,
+        lua_value(b"{[\"if\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"in".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"in\"] = true}")?,
+        lua_value(b"{[\"in\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"local".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"local\"] = true}")?,
+        lua_value(b"{[\"local\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"nil".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"nil\"] = true}")?,
+        lua_value(b"{[\"nil\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"not".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"not\"] = true}")?,
+        lua_value(b"{[\"not\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"or".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"or\"] = true}")?,
+        lua_value(b"{[\"or\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"repeat".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"repeat\"] = true}")?,
+        lua_value(b"{[\"repeat\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"return".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"return\"] = true}")?,
+        lua_value(b"{[\"return\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"then".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"then\"] = true}")?,
+        lua_value(b"{[\"then\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"true".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"true\"] = true}")?,
+        lua_value(b"{[\"true\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"until".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"until\"] = true}")?,
+        lua_value(b"{[\"until\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
         LuaValue::Table(vec![LuaTableEntry::KeyValue(
             b"while".into(),
             LuaValue::Boolean(true)
         ),]),
-        lua_value(b"{[\"while\"] = true}")?,
+        lua_value(b"{[\"while\"] = true}", MAX_DEPTH)?,
     );
 
     Ok(())
@@ -246,360 +249,360 @@ fn contains_keyword() -> Result {
     // Starts with a keyword
     assert_eq!(
         vec![("and1", LuaValue::Boolean(true)),],
-        script(b"and1 = true\n")?
+        script(b"and1 = true\n", MAX_DEPTH)?
     );
     assert_eq!(
         vec![("break1", LuaValue::Boolean(true)),],
-        script(b"break1 = true\n")?,
+        script(b"break1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("do1", LuaValue::Boolean(true)),],
-        script(b"do1 = true\n")?,
+        script(b"do1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("else1", LuaValue::Boolean(true)),],
-        script(b"else1 = true\n")?,
+        script(b"else1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("elseif1", LuaValue::Boolean(true)),],
-        script(b"elseif1 = true\n")?,
+        script(b"elseif1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("end1", LuaValue::Boolean(true)),],
-        script(b"end1 = true\n")?,
+        script(b"end1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("false1", LuaValue::Boolean(true)),],
-        script(b"false1 = true\n")?,
+        script(b"false1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("for1", LuaValue::Boolean(true)),],
-        script(b"for1 = true\n")?,
+        script(b"for1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("function1", LuaValue::Boolean(true)),],
-        script(b"function1 = true\n")?,
+        script(b"function1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("goto1", LuaValue::Boolean(true)),],
-        script(b"goto1 = true\n")?,
+        script(b"goto1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("if1", LuaValue::Boolean(true)),],
-        script(b"if1 = true\n")?,
+        script(b"if1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("in1", LuaValue::Boolean(true)),],
-        script(b"in1 = true\n")?,
+        script(b"in1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("local1", LuaValue::Boolean(true)),],
-        script(b"local1 = true\n")?,
+        script(b"local1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("nil1", LuaValue::Boolean(true)),],
-        script(b"nil1 = true\n")?,
+        script(b"nil1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("not1", LuaValue::Boolean(true)),],
-        script(b"not1 = true\n")?,
+        script(b"not1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("or1", LuaValue::Boolean(true)),],
-        script(b"or1 = true\n")?,
+        script(b"or1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("repeat1", LuaValue::Boolean(true)),],
-        script(b"repeat1 = true\n")?,
+        script(b"repeat1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("return1", LuaValue::Boolean(true)),],
-        script(b"return1 = true\n")?,
+        script(b"return1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("then1", LuaValue::Boolean(true)),],
-        script(b"then1 = true\n")?,
+        script(b"then1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("true1", LuaValue::Boolean(true)),],
-        script(b"true1 = true\n")?,
+        script(b"true1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("until1", LuaValue::Boolean(true)),],
-        script(b"until1 = true\n")?,
+        script(b"until1 = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("while1", LuaValue::Boolean(true)),],
-        script(b"while1 = true\n")?,
+        script(b"while1 = true\n", MAX_DEPTH)?,
     );
 
     // Ends with a keyword
     assert_eq!(
         vec![("_and", LuaValue::Boolean(true)),],
-        script(b"_and = true\n")?,
+        script(b"_and = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_break", LuaValue::Boolean(true)),],
-        script(b"_break = true\n")?,
+        script(b"_break = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_do", LuaValue::Boolean(true)),],
-        script(b"_do = true\n")?,
+        script(b"_do = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_else", LuaValue::Boolean(true)),],
-        script(b"_else = true\n")?,
+        script(b"_else = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_elseif", LuaValue::Boolean(true)),],
-        script(b"_elseif = true\n")?,
+        script(b"_elseif = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_end", LuaValue::Boolean(true)),],
-        script(b"_end = true\n")?,
+        script(b"_end = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_false", LuaValue::Boolean(true)),],
-        script(b"_false = true\n")?,
+        script(b"_false = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_for", LuaValue::Boolean(true)),],
-        script(b"_for = true\n")?,
+        script(b"_for = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_function", LuaValue::Boolean(true)),],
-        script(b"_function = true\n")?,
+        script(b"_function = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_goto", LuaValue::Boolean(true)),],
-        script(b"_goto = true\n")?,
+        script(b"_goto = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_if", LuaValue::Boolean(true)),],
-        script(b"_if = true\n")?,
+        script(b"_if = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_in", LuaValue::Boolean(true)),],
-        script(b"_in = true\n")?,
+        script(b"_in = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_local", LuaValue::Boolean(true)),],
-        script(b"_local = true\n")?,
+        script(b"_local = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_nil", LuaValue::Boolean(true)),],
-        script(b"_nil = true\n")?,
+        script(b"_nil = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_not", LuaValue::Boolean(true)),],
-        script(b"_not = true\n")?,
+        script(b"_not = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_or", LuaValue::Boolean(true)),],
-        script(b"_or = true\n")?,
+        script(b"_or = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_repeat", LuaValue::Boolean(true)),],
-        script(b"_repeat = true\n")?,
+        script(b"_repeat = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_return", LuaValue::Boolean(true)),],
-        script(b"_return = true\n")?,
+        script(b"_return = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_then", LuaValue::Boolean(true)),],
-        script(b"_then = true\n")?,
+        script(b"_then = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_true", LuaValue::Boolean(true)),],
-        script(b"_true = true\n")?,
+        script(b"_true = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_until", LuaValue::Boolean(true)),],
-        script(b"_until = true\n")?,
+        script(b"_until = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("_while", LuaValue::Boolean(true)),],
-        script(b"_while = true\n")?,
+        script(b"_while = true\n", MAX_DEPTH)?,
     );
 
     // Keyword not in lower case
     assert_eq!(
         vec![("AND", LuaValue::Boolean(true)),],
-        script(b"AND = true\n")?,
+        script(b"AND = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("BREAK", LuaValue::Boolean(true)),],
-        script(b"BREAK = true\n")?,
+        script(b"BREAK = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("DO", LuaValue::Boolean(true)),],
-        script(b"DO = true\n")?,
+        script(b"DO = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("ELSE", LuaValue::Boolean(true)),],
-        script(b"ELSE = true\n")?,
+        script(b"ELSE = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("ELSEIF", LuaValue::Boolean(true)),],
-        script(b"ELSEIF = true\n")?,
+        script(b"ELSEIF = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("END", LuaValue::Boolean(true)),],
-        script(b"END = true\n")?,
+        script(b"END = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("FALSE", LuaValue::Boolean(true)),],
-        script(b"FALSE = true\n")?,
+        script(b"FALSE = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("FOR", LuaValue::Boolean(true)),],
-        script(b"FOR = true\n")?,
+        script(b"FOR = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("FUNCTION", LuaValue::Boolean(true)),],
-        script(b"FUNCTION = true\n")?,
+        script(b"FUNCTION = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("GOTO", LuaValue::Boolean(true)),],
-        script(b"GOTO = true\n")?,
+        script(b"GOTO = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("IF", LuaValue::Boolean(true)),],
-        script(b"IF = true\n")?,
+        script(b"IF = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("IN", LuaValue::Boolean(true)),],
-        script(b"IN = true\n")?,
+        script(b"IN = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("LOCAL", LuaValue::Boolean(true)),],
-        script(b"LOCAL = true\n")?,
+        script(b"LOCAL = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("NIL", LuaValue::Boolean(true)),],
-        script(b"NIL = true\n")?,
+        script(b"NIL = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("NOT", LuaValue::Boolean(true)),],
-        script(b"NOT = true\n")?,
+        script(b"NOT = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("OR", LuaValue::Boolean(true)),],
-        script(b"OR = true\n")?,
+        script(b"OR = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("REPEAT", LuaValue::Boolean(true)),],
-        script(b"REPEAT = true\n")?,
+        script(b"REPEAT = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("RETURN", LuaValue::Boolean(true)),],
-        script(b"RETURN = true\n")?,
+        script(b"RETURN = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("THEN", LuaValue::Boolean(true)),],
-        script(b"THEN = true\n")?,
+        script(b"THEN = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("TRUE", LuaValue::Boolean(true)),],
-        script(b"TRUE = true\n")?,
+        script(b"TRUE = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("UNTIL", LuaValue::Boolean(true)),],
-        script(b"UNTIL = true\n")?,
+        script(b"UNTIL = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("WHILE", LuaValue::Boolean(true)),],
-        script(b"WHILE = true\n")?,
+        script(b"WHILE = true\n", MAX_DEPTH)?,
     );
 
     assert_eq!(
         vec![("And", LuaValue::Boolean(true)),],
-        script(b"And = true\n")?,
+        script(b"And = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Break", LuaValue::Boolean(true)),],
-        script(b"Break = true\n")?,
+        script(b"Break = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Do", LuaValue::Boolean(true)),],
-        script(b"Do = true\n")?,
+        script(b"Do = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Else", LuaValue::Boolean(true)),],
-        script(b"Else = true\n")?,
+        script(b"Else = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Elseif", LuaValue::Boolean(true)),],
-        script(b"Elseif = true\n")?,
+        script(b"Elseif = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("End", LuaValue::Boolean(true)),],
-        script(b"End = true\n")?,
+        script(b"End = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("False", LuaValue::Boolean(true)),],
-        script(b"False = true\n")?,
+        script(b"False = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("For", LuaValue::Boolean(true)),],
-        script(b"For = true\n")?,
+        script(b"For = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Function", LuaValue::Boolean(true)),],
-        script(b"Function = true\n")?,
+        script(b"Function = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Goto", LuaValue::Boolean(true)),],
-        script(b"Goto = true\n")?,
+        script(b"Goto = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("If", LuaValue::Boolean(true)),],
-        script(b"If = true\n")?,
+        script(b"If = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("In", LuaValue::Boolean(true)),],
-        script(b"In = true\n")?,
+        script(b"In = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Local", LuaValue::Boolean(true)),],
-        script(b"Local = true\n")?,
+        script(b"Local = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Nil", LuaValue::Boolean(true)),],
-        script(b"Nil = true\n")?,
+        script(b"Nil = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Not", LuaValue::Boolean(true)),],
-        script(b"Not = true\n")?,
+        script(b"Not = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Or", LuaValue::Boolean(true)),],
-        script(b"Or = true\n")?,
+        script(b"Or = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Repeat", LuaValue::Boolean(true)),],
-        script(b"Repeat = true\n")?,
+        script(b"Repeat = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Return", LuaValue::Boolean(true)),],
-        script(b"Return = true\n")?,
+        script(b"Return = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Then", LuaValue::Boolean(true)),],
-        script(b"Then = true\n")?,
+        script(b"Then = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("True", LuaValue::Boolean(true)),],
-        script(b"True = true\n")?,
+        script(b"True = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("Until", LuaValue::Boolean(true)),],
-        script(b"Until = true\n")?,
+        script(b"Until = true\n", MAX_DEPTH)?,
     );
     assert_eq!(
         vec![("While", LuaValue::Boolean(true)),],
-        script(b"While = true\n")?,
+        script(b"While = true\n", MAX_DEPTH)?,
     );
 
     Ok(())
@@ -609,46 +612,46 @@ fn contains_keyword() -> Result {
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn invalid() {
     // Starts with a number
-    assert!(script(b"1a = true\n").is_err());
-    assert!(script(b"2a = true\n").is_err());
-    assert!(script(b"3a = true\n").is_err());
-    assert!(script(b"4a = true\n").is_err());
-    assert!(script(b"5a = true\n").is_err());
-    assert!(script(b"6a = true\n").is_err());
-    assert!(script(b"7a = true\n").is_err());
-    assert!(script(b"8a = true\n").is_err());
-    assert!(script(b"9a = true\n").is_err());
-    assert!(script(b"0a = true\n").is_err());
+    assert!(script(b"1a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"2a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"3a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"4a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"5a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"6a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"7a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"8a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"9a = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"0a = true\n", MAX_DEPTH).is_err());
 
     // Is a number
-    assert!(script(b"1 = true\n").is_err());
-    assert!(script(b"2 = true\n").is_err());
-    assert!(script(b"3 = true\n").is_err());
-    assert!(script(b"4 = true\n").is_err());
-    assert!(script(b"5 = true\n").is_err());
-    assert!(script(b"6 = true\n").is_err());
-    assert!(script(b"7 = true\n").is_err());
-    assert!(script(b"8 = true\n").is_err());
-    assert!(script(b"9 = true\n").is_err());
-    assert!(script(b"0 = true\n").is_err());
+    assert!(script(b"1 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"2 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"3 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"4 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"5 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"6 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"7 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"8 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"9 = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"0 = true\n", MAX_DEPTH).is_err());
 
     // Empty
-    assert!(script(b" = true\n").is_err());
+    assert!(script(b" = true\n", MAX_DEPTH).is_err());
 
     // Other characters
-    assert!(script(b"[] = true\n").is_err());
-    assert!(script(b"[[]] = true\n").is_err());
-    assert!(script(b"{} = true\n").is_err());
-    assert!(script(b"$ = true\n").is_err());
-    assert!(script(b"\"\" = true\n").is_err());
-    assert!(script(b"'' = true\n").is_err());
-    assert!(script(b"\\ = true\n").is_err());
-    assert!(script("Français = true\n".as_bytes()).is_err());
+    assert!(script(b"[] = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"[[]] = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"{} = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"$ = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"\"\" = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"'' = true\n", MAX_DEPTH).is_err());
+    assert!(script(b"\\ = true\n", MAX_DEPTH).is_err());
+    assert!(script("Français = true\n".as_bytes(), MAX_DEPTH).is_err());
 
     // Inside table identifiers
-    assert!(script("{Français = true}\n".as_bytes()).is_err());
-    assert!(script(b"{1 = true}\n").is_err());
-    assert!(script(b"{[[foo]] = true}\n").is_err());
-    assert!(script(b"{'foo' = true}\n").is_err());
-    assert!(script(b"{\"foo\" = true}\n").is_err());
+    assert!(script("{Français = true}\n".as_bytes(), MAX_DEPTH).is_err());
+    assert!(script(b"{1 = true}\n", MAX_DEPTH).is_err());
+    assert!(script(b"{[[foo]] = true}\n", MAX_DEPTH).is_err());
+    assert!(script(b"{'foo' = true}\n", MAX_DEPTH).is_err());
+    assert!(script(b"{\"foo\" = true}\n", MAX_DEPTH).is_err());
 }

--- a/tests/numerals.rs
+++ b/tests/numerals.rs
@@ -2,8 +2,6 @@
 mod common;
 
 use crate::common::check;
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-use serde_luaq::lua_value;
 use serde_luaq::LuaValue;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -135,13 +133,16 @@ fn decimal_floats() {
 /// Hex floats
 #[test]
 fn hex_floats() {
+    use crate::common::MAX_DEPTH;
+    use serde_luaq::lua_value;
+
     // lua-tests/math.lua, hex
     check(b"0E+1", LuaValue::float(0.));
 
     // We shouldn't be able to evaluate an expression, which could be confused
     // with a decimal exponent.
-    assert!(lua_value(b"0xE+1").is_err());
-    assert!(lua_value(b"0xE-1").is_err());
+    assert!(lua_value(b"0xE+1", MAX_DEPTH).is_err());
+    assert!(lua_value(b"0xE-1", MAX_DEPTH).is_err());
 
     check(b"0x1.fp10", LuaValue::float(1984.));
 

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -1,7 +1,7 @@
 //! String literal tests
 mod common;
 
-use crate::common::check;
+use crate::common::{check, MAX_DEPTH};
 use serde_luaq::{lua_value, LuaTableEntry, LuaValue};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -132,15 +132,15 @@ fn long_string() {
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn newlines() {
     // Short strings need to escape newlines
-    assert!(lua_value(b"'\nfoo'").is_err());
-    assert!(lua_value(b"'\rfoo'").is_err());
-    assert!(lua_value(b"'\r\nfoo'").is_err());
-    assert!(lua_value(b"'\n\rfoo'").is_err());
+    assert!(lua_value(b"'\nfoo'", MAX_DEPTH).is_err());
+    assert!(lua_value(b"'\rfoo'", MAX_DEPTH).is_err());
+    assert!(lua_value(b"'\r\nfoo'", MAX_DEPTH).is_err());
+    assert!(lua_value(b"'\n\rfoo'", MAX_DEPTH).is_err());
 
-    assert!(lua_value(b"\"\nfoo\"").is_err());
-    assert!(lua_value(b"\"\rfoo\"").is_err());
-    assert!(lua_value(b"\"\r\nfoo\"").is_err());
-    assert!(lua_value(b"\"\n\rfoo\"").is_err());
+    assert!(lua_value(b"\"\nfoo\"", MAX_DEPTH).is_err());
+    assert!(lua_value(b"\"\rfoo\"", MAX_DEPTH).is_err());
+    assert!(lua_value(b"\"\r\nfoo\"", MAX_DEPTH).is_err());
+    assert!(lua_value(b"\"\n\rfoo\"", MAX_DEPTH).is_err());
 
     // Backslash with line break.
     // Lua normalises these to the platform's newline character, but we retain these as-is because
@@ -340,49 +340,49 @@ fn unicode_escapes() {
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn invalid_escapes() {
-    assert!(lua_value(br"'\256'").is_err());
-    assert!(lua_value(br"'\c'").is_err());
-    assert!(lua_value(br"'\x'").is_err());
-    assert!(lua_value(br"'\x0'").is_err());
-    assert!(lua_value(br"'\xyz'").is_err());
-    assert!(lua_value(br"'\u{80000000}'").is_err());
-    assert!(lua_value(br"'\u{-80}'").is_err());
+    assert!(lua_value(br"'\256'", MAX_DEPTH).is_err());
+    assert!(lua_value(br"'\c'", MAX_DEPTH).is_err());
+    assert!(lua_value(br"'\x'", MAX_DEPTH).is_err());
+    assert!(lua_value(br"'\x0'", MAX_DEPTH).is_err());
+    assert!(lua_value(br"'\xyz'", MAX_DEPTH).is_err());
+    assert!(lua_value(br"'\u{80000000}'", MAX_DEPTH).is_err());
+    assert!(lua_value(br"'\u{-80}'", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn borrows() -> Result {
     // Empty strings
-    assert!(lua_value(b"[[]]")?.is_borrowed());
-    assert!(lua_value(b"[=[]=]")?.is_borrowed());
-    assert!(lua_value(b"''")?.is_borrowed());
-    assert!(lua_value(b"\"\"")?.is_borrowed());
+    assert!(lua_value(b"[[]]", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"[=[]=]", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"''", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"\"\"", MAX_DEPTH)?.is_borrowed());
 
     // No escape sequences
-    assert!(lua_value(b"[[hello]]")?.is_borrowed());
-    assert!(lua_value(b"[=[hello]=]")?.is_borrowed());
-    assert!(lua_value(b"'hello'")?.is_borrowed());
-    assert!(lua_value(b"\"hello\"")?.is_borrowed());
+    assert!(lua_value(b"[[hello]]", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"[=[hello]=]", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"'hello'", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"\"hello\"", MAX_DEPTH)?.is_borrowed());
 
     // Escapes are ignored for long bracket strings
-    assert!(lua_value(br"[[hello\nworld]]")?.is_borrowed());
-    assert!(lua_value(br"[=[hello\nworld]=]")?.is_borrowed());
+    assert!(lua_value(br"[[hello\nworld]]", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(br"[=[hello\nworld]=]", MAX_DEPTH)?.is_borrowed());
 
     // Newline character should also be included
-    assert!(lua_value(b"[[hello\nworld]]")?.is_borrowed());
-    assert!(lua_value(b"[=[hello\nworld]=]")?.is_borrowed());
+    assert!(lua_value(b"[[hello\nworld]]", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"[=[hello\nworld]=]", MAX_DEPTH)?.is_borrowed());
 
     // Strings containing _only_ an escape are borrowed
-    assert!(lua_value(br"'\n'")?.is_borrowed());
-    assert!(lua_value(b"\"\\n\"")?.is_borrowed());
+    assert!(lua_value(br"'\n'", MAX_DEPTH)?.is_borrowed());
+    assert!(lua_value(b"\"\\n\"", MAX_DEPTH)?.is_borrowed());
 
     // Strings containing multiple escapes are owned
-    assert!(!lua_value(br"'\r\n'")?.is_borrowed());
-    assert!(!lua_value(b"\"\\r\\n\"")?.is_borrowed());
+    assert!(!lua_value(br"'\r\n'", MAX_DEPTH)?.is_borrowed());
+    assert!(!lua_value(b"\"\\r\\n\"", MAX_DEPTH)?.is_borrowed());
 
     // Strings containing escapes and non-escaped are owned
-    assert!(!lua_value(br"'hello\n'")?.is_borrowed());
-    assert!(!lua_value(b"\"hello\\n\"")?.is_borrowed());
+    assert!(!lua_value(br"'hello\n'", MAX_DEPTH)?.is_borrowed());
+    assert!(!lua_value(b"\"hello\\n\"", MAX_DEPTH)?.is_borrowed());
 
     Ok(())
 }

--- a/tests/unsupported.rs
+++ b/tests/unsupported.rs
@@ -1,7 +1,7 @@
 //! Tests for unsupported language features, which should _fail_ parsing.
 mod common;
 
-use crate::common::should_error;
+use crate::common::{should_error, MAX_DEPTH};
 use serde_luaq::{lua_value, return_statement, script, LuaValue};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -102,7 +102,7 @@ fn bitwise_not() {
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn block_do() {
-    assert!(script(b"a = 3\ndo\n  a = 4\nend\n").is_err());
+    assert!(script(b"a = 3\ndo\n  a = 4\nend\n", MAX_DEPTH).is_err());
 }
 
 #[test]
@@ -116,29 +116,29 @@ fn coroutine() {
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn functions() {
-    assert!(script(b"function a()\n  return 3\nend\nb = a()\n").is_err());
-    assert!(script(b"function a()\n  return 3\nend\nb=a()\n").is_err());
-    assert!(script(b"return 3\n").is_err());
-    assert!(lua_value(b"return 3\n").is_err());
+    assert!(script(b"function a()\n  return 3\nend\nb = a()\n", MAX_DEPTH).is_err());
+    assert!(script(b"function a()\n  return 3\nend\nb=a()\n", MAX_DEPTH).is_err());
+    assert!(script(b"return 3\n", MAX_DEPTH).is_err());
+    assert!(lua_value(b"return 3\n", MAX_DEPTH).is_err());
 
     // But this should be valid for return statements.
     assert_eq!(
         LuaValue::integer(3),
-        return_statement(b"return 3\n").unwrap()
+        return_statement(b"return 3\n", MAX_DEPTH).unwrap()
     );
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn length_operator() {
-    assert!(script(b"a = [1, 2, 3]\nb = #a\n").is_err());
-    assert!(script(b"a=[1,2,3]\nb=#a\n").is_err());
+    assert!(script(b"a = [1, 2, 3]\nb = #a\n", MAX_DEPTH).is_err());
+    assert!(script(b"a=[1,2,3]\nb=#a\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn local() {
-    assert!(script(b"local a = 3\n").is_err());
+    assert!(script(b"local a = 3\n", MAX_DEPTH).is_err());
 }
 
 #[test]
@@ -168,48 +168,48 @@ fn parentheses() {
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn referencing() {
-    assert!(script(b"a = 3\nb = a\n").is_err());
-    assert!(script(b"a = {}\na.b = 3\n").is_err());
+    assert!(script(b"a = 3\nb = a\n", MAX_DEPTH).is_err());
+    assert!(script(b"a = {}\na.b = 3\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_eq() {
-    assert!(script(b"a = 3\nb = a == 3\n").is_err());
+    assert!(script(b"a = 3\nb = a == 3\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_neq() {
-    assert!(script(b"a = 3\nb = a ~= 1\n").is_err());
+    assert!(script(b"a = 3\nb = a ~= 1\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_lt() {
-    assert!(script(b"a = 3\nb = a < 1\n").is_err());
-    assert!(script(b"a = 3\nb=a<1\n").is_err());
+    assert!(script(b"a = 3\nb = a < 1\n", MAX_DEPTH).is_err());
+    assert!(script(b"a = 3\nb=a<1\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_lte() {
-    assert!(script(b"a = 3\nb = a <= 1\n").is_err());
-    assert!(script(b"a = 3\nb=a<=1\n").is_err());
+    assert!(script(b"a = 3\nb = a <= 1\n", MAX_DEPTH).is_err());
+    assert!(script(b"a = 3\nb=a<=1\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_gt() {
-    assert!(script(b"a = 3\nb = a > 1\n").is_err());
-    assert!(script(b"a = 3\nb=a>1\n").is_err());
+    assert!(script(b"a = 3\nb = a > 1\n", MAX_DEPTH).is_err());
+    assert!(script(b"a = 3\nb=a>1\n", MAX_DEPTH).is_err());
 }
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn relational_gte() {
-    assert!(script(b"a = 3\nb = a >= 1\n").is_err());
-    assert!(script(b"a = 3\nb=a>=1\n").is_err());
+    assert!(script(b"a = 3\nb = a >= 1\n", MAX_DEPTH).is_err());
+    assert!(script(b"a = 3\nb=a>=1\n", MAX_DEPTH).is_err());
 }
 
 #[test]
@@ -222,6 +222,6 @@ fn string_concat() {
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn vararg_assignments() {
-    assert!(script(b"a, b = 'hello', 'world'\n").is_err());
-    assert!(script(b"a,b='hello','world'\n").is_err());
+    assert!(script(b"a, b = 'hello', 'world'\n", MAX_DEPTH).is_err());
+    assert!(script(b"a,b='hello','world'\n", MAX_DEPTH).is_err());
 }


### PR DESCRIPTION
It's possible to trigger a stack overflow with 8KiB of `{` followed by the same number of `}`. The exact amount required to trigger a stack overflow depends on the platform and build configuration, but it is much lower for debug builds.

It's possible to crash Lua in the same way.

`rust-peg` doesn't support recursion limits, so this is based on https://github.com/kevinmehall/rust-peg/issues/282#issuecomment-2168715879 and https://github.com/kevinmehall/rust-peg/issues/282#issuecomment-2169784035:

- add a `max_depth: usize` parameter to all PEG functions that support recursion
- `lua_value()` decrements `max_depth` before passing it to `table()`
- when `table()` matches the opening brace (`{`), it returns an error if `max_depth == 0`

This means the recursion check happens early on in the table parsing process so we can stop if we get too deep.

Unfortunately, fixing this breaks the API.