### PR TITLE
Simplify and fix string handling, various performance tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -608,7 +608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/serde_luaq/examples/lua_to_json.rs
+++ b/serde_luaq/examples/lua_to_json.rs
@@ -66,6 +66,14 @@ struct Args {
     /// Use lossy string conversion, rather than erroring.
     #[arg(long)]
     lossy_string: bool,
+
+    /// Stop once the Lua value has been loaded.
+    #[arg(long)]
+    no_json: bool,
+
+    /// Convert the Lua value to a JSON object, but don't serialise it.
+    #[arg(long)]
+    no_output: bool,
 }
 
 fn main() -> Result {
@@ -95,7 +103,15 @@ fn main() -> Result {
         LuaInputFormat::Return => return_statement(&buf, args.max_depth)?,
     };
 
+    if args.no_json {
+        return Ok(());
+    }
+
     let json_value = to_json_value(lua_value, &opts)?;
+
+    if args.no_output {
+        return Ok(());
+    }
 
     let f: Box<dyn Write> = if let Some(output) = args.output {
         Box::new(File::options().create_new(true).write(true).open(output)?)

--- a/serde_luaq/src/lib.rs
+++ b/serde_luaq/src/lib.rs
@@ -62,7 +62,7 @@
 //! assert_eq!(
 //!     expected,
 //!     from_slice(
-//!         b"{a=true, [[[b]]]={[3] = 3, 0x1, 2}, ['c'] = { foo = \"bar\" }}",
+//!         b"{a=true, [ [[b]] ]={[3] = 3, 0x1, 2}, ['c'] = { foo = \"bar\" }}",
 //!         LuaFormat::Value,
 //!         /* maximum table depth */ 16,
 //!     ).unwrap(),

--- a/serde_luaq/src/peg_parser.rs
+++ b/serde_luaq/src/peg_parser.rs
@@ -382,10 +382,6 @@ peg::parser! {
         // TODO: find a way to make this work with arbitrary levels.
         rule longer_string(level: usize) -> Cow<'input, [u8]>
             =
-                // Matches empty strings
-                "[" "="*<{level}> "[" linebreak()? "]" "="*<{level}> "]" { EMPTY } /
-
-                // Matches non-empty strings
                 "[" "="*<{level}> "["
                 linebreak()?
                 v:$(
@@ -393,16 +389,12 @@ peg::parser! {
                         !("]" "="*<{level}> "]")
                         [_]
                     )+
-                )
+                )?
                 "]" "="*<{level}> "]"
-                { v.into() }
+                { v.map(Cow::Borrowed).unwrap_or(EMPTY) }
 
         rule long_string() -> Cow<'input, [u8]>
             =
-                // Matches empty strings
-                "[[" linebreak()? "]]" { EMPTY } /
-
-                // Matches non-empty strings
                 "[["
                 linebreak()?
                 v:$(
@@ -410,8 +402,9 @@ peg::parser! {
                         !"]]"
                         [_]
                     )+
-                )
-                "]]" { v.into() }
+                )?
+                "]]"
+                { v.map(Cow::Borrowed).unwrap_or(EMPTY) }
 
         /// Parses a string.
         rule string() -> Cow<'input, [u8]>

--- a/serde_luaq/tests/json.rs
+++ b/serde_luaq/tests/json.rs
@@ -110,7 +110,7 @@ fn table_coersion() -> Result {
         json!({"a": 1, "b": 2, "c": 3, "d": 4}),
         to_json_value(
             lua_value(
-                b"{['a'] = 1, [\"b\"] = 2, [[[c]]] = 3, [[=[d]=]] = 4}",
+                b"{['a'] = 1, [\"b\"] = 2, [ [[c]] ] = 3, [ [=[d]=]] = 4}",
                 MAX_DEPTH
             )?,
             &DEFAULT_OPTS
@@ -148,7 +148,7 @@ fn table_coersion() -> Result {
         json!({"true": 1, "false": 2, "nil": 3}),
         to_json_value(
             lua_value(
-                b"{['true'] = 0, [true] = 1, [false] = 0, ['false'] = 2, [[[nil]]] = 0, [nil] = 3}",
+                b"{['true'] = 0, [true] = 1, [false] = 0, ['false'] = 2, [ [[nil]] ] = 0, [nil] = 3}",
                 MAX_DEPTH,
             )?,
             &DEFAULT_OPTS

--- a/serde_luaq/tests/strings.rs
+++ b/serde_luaq/tests/strings.rs
@@ -135,6 +135,22 @@ fn long_string() {
             LuaTableEntry::Value(LuaValue::String(b"?".into())),
         ]),
     );
+
+    // When a long string is used as a table key, there must be a space before
+    // the long string.
+    let expected = LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::String(b"a".into()),
+        LuaValue::String(b"b".into()),
+    )]);
+    check(b"{[ [[a]]]=[[b]]}", &expected);
+    check(b"{[ [=[a]=]]=[[b]]}", &expected);
+    check(b"{[ [[a]]] = [[b]]}", &expected);
+    check(b"{[ [[a]] ] = [[b]]}", &expected);
+    should_error(b"{[[[a]]] = [[b]]}");
+    should_error(b"{[[[a]] ] = [[b]]}");
+    should_error(b"{c = 3, [[[a]]] = [[b]]}");
+    should_error(b"{c = 3, [[[a]] ] = [[b]]}");
+    should_error(b"{['a'] = 1, [\"b\"] = 2, [[[c]]] = 3, [[=[d]=]] = 4}");
 }
 
 #[test]

--- a/serde_luaq/tests/tables.rs
+++ b/serde_luaq/tests/tables.rs
@@ -41,7 +41,7 @@ fn simple_table() -> Result {
             "a",
             "b";
             x3yz = 0x12,
-            [[[foo]]] = "bar",
+            [ [[foo]]] = "bar",
             [5] = 42,
             [0xa] = 3.14,
         }


### PR DESCRIPTION
- `lua_to_json`: add `--no_json` and `--no_output` options for cleaner performance testing
- Make long and longer string parsing less complicated
- Make short strings use the same code for single and double quotes
- Make short strings pre-allocate memory when it has to copy
- Handle whitespace in `lua_value` and `table_entry` once, rather than in each variant
- Fix: Lua 5.4.8 requires long and longer strings in a table key have whitespace before them:

  ```
  > a = {[[[hello]]] = [[world]]}
  stdin:1: '}' expected near ']'
  > a = {[ [[hello]]] = [[world]]}
  > a.hello
  world

  > a = {[[=[hello]=]] = [[world]]}
  stdin:1: '}' expected near '='
  > a = {[ [=[hello]=]] = [[world]]}
  > a.hello
  world
  ```
