### PR TITLE
Parse table entry bare values first

### DIFF
--- a/serde_luaq/tests/strings.rs
+++ b/serde_luaq/tests/strings.rs
@@ -135,22 +135,6 @@ fn long_string() {
             LuaTableEntry::Value(LuaValue::String(b"?".into())),
         ]),
     );
-
-    // When a long string is used as a table key, there must be a space before
-    // the long string.
-    let expected = LuaValue::Table(vec![LuaTableEntry::KeyValue(
-        LuaValue::String(b"a".into()),
-        LuaValue::String(b"b".into()),
-    )]);
-    check(b"{[ [[a]]]=[[b]]}", &expected);
-    check(b"{[ [=[a]=]]=[[b]]}", &expected);
-    check(b"{[ [[a]]] = [[b]]}", &expected);
-    check(b"{[ [[a]] ] = [[b]]}", &expected);
-    should_error(b"{[[[a]]] = [[b]]}");
-    should_error(b"{[[[a]] ] = [[b]]}");
-    should_error(b"{c = 3, [[[a]]] = [[b]]}");
-    should_error(b"{c = 3, [[[a]] ] = [[b]]}");
-    should_error(b"{['a'] = 1, [\"b\"] = 2, [[[c]]] = 3, [[=[d]=]] = 4}");
 }
 
 #[test]

--- a/serde_luaq/tests/tables.rs
+++ b/serde_luaq/tests/tables.rs
@@ -163,3 +163,39 @@ fn recursion() -> Result {
 
     Ok(())
 }
+
+/// Tests for handling long strings in tables.
+#[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+fn long_string_tables() -> Result {
+    // When a long string is used as a table key, there must be a space before
+    // the long string.
+    let expected = LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::String(b"a".into()),
+        LuaValue::String(b"b".into()),
+    )]);
+    check(b"{[ [[a]]]=[[b]]}", &expected);
+    check(b"{[ [=[a]=]]=[[b]]}", &expected);
+    check(b"{[ [[a]]] = [[b]]}", &expected);
+    check(b"{[ [[a]] ] = [[b]]}", &expected);
+
+    // Deceptive syntax
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::String(b"[a".into()))]);
+    check(b"{[[[a]]}", &expected);
+    check(b"{[=[[a]=]}", &expected);
+
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::String(
+        b"=[a]=".into(),
+    ))]);
+    check(b"{[[=[a]=]]}", &expected);
+    check(b"{[==[=[a]=]==]}", &expected);
+
+    // These are rejected by Lua as syntax errors
+    should_error(b"{[[[a]]] = [[b]]}");
+    should_error(b"{[[[a]] ] = [[b]]}");
+    should_error(b"{c = 3, [[[a]]] = [[b]]}");
+    should_error(b"{c = 3, [[[a]] ] = [[b]]}");
+    should_error(b"{['a'] = 1, [\"b\"] = 2, [[[c]]] = 3, [[=[d]=]] = 4}");
+
+    Ok(())
+}

--- a/serde_luaq/tests/tables.rs
+++ b/serde_luaq/tests/tables.rs
@@ -190,6 +190,12 @@ fn long_string_tables() -> Result {
     check(b"{[[=[a]=]]}", &expected);
     check(b"{[==[=[a]=]==]}", &expected);
 
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::String(
+        b"[a] = [[foo".into(),
+    ))]);
+    check(b"{[[[a] = [[foo]]}", &expected);
+    check(b"{[=[[a] = [[foo]=]}", &expected);
+
     // These are rejected by Lua as syntax errors
     should_error(b"{[[[a]]] = [[b]]}");
     should_error(b"{[[[a]] ] = [[b]]}");


### PR DESCRIPTION
Parse table entries as a bare `Value` first, then as a `KeyValue`. This is a simpler fix for the "long strings as table keys" issue from #14.

This also moves some of the table-related tests from the strings tests to tables tests, and expands them with some more deceptive syntax.
