### PR TITLE
Box up LuaTableEntry, add specialisations

### DIFF
--- a/serde_luaq/src/de.rs
+++ b/serde_luaq/src/de.rs
@@ -418,8 +418,8 @@ impl LuaTableEntry<'_> {
     #[cold]
     fn unexpected(&self) -> Unexpected<'_> {
         match self {
-            LuaTableEntry::NameValue(_, _) | LuaTableEntry::KeyValue(_, _) => Unexpected::Map,
-            LuaTableEntry::Value(_) => Unexpected::Seq,
+            LuaTableEntry::NameValue(_) | LuaTableEntry::KeyValue(_) => Unexpected::Map,
+            LuaTableEntry::Value(_) | LuaTableEntry::NumberValue(_) => Unexpected::Seq,
         }
     }
 }
@@ -448,7 +448,8 @@ impl<'a> SeqDeserializer<'a> {
             if !matches!(entry, LuaTableEntry::Value(_)) {
                 if !matches!(
                     entry,
-                    LuaTableEntry::KeyValue(LuaValue::Number(LuaNumber::Integer(_)), _)
+                    LuaTableEntry::KeyValue(b)
+                    if matches!(b.0, LuaValue::Number(LuaNumber::Integer(_)))
                 ) {
                     return Err(entry.invalid_type(&"Table with integer or implicit keys"));
                 }
@@ -474,12 +475,19 @@ impl<'a> SeqDeserializer<'a> {
         let mut highest_key = 0;
         for entry in vec {
             match entry {
-                LuaTableEntry::KeyValue(LuaValue::Number(LuaNumber::Integer(key)), value) => {
+                // This would be much cleaner with box_patterns:
+                // https://doc.rust-lang.org/beta/unstable-book/language-features/box-patterns.html
+                LuaTableEntry::KeyValue(entry)
+                    if matches!(entry.0, LuaValue::Number(LuaNumber::Integer(_))) =>
+                {
+                    let (LuaValue::Number(LuaNumber::Integer(key)), value) = *entry else {
+                        unreachable!();
+                    };
                     h.insert(key, value);
                     highest_key = highest_key.max(key);
                 }
                 LuaTableEntry::Value(value) => {
-                    h.insert(i, value);
+                    h.insert(i, *value);
                     i += 1;
                     highest_key = highest_key.max(i);
                 }
@@ -564,19 +572,27 @@ where
     {
         // Copy the entry without a value and pass to MapKeyDeserializer
         match self.iter.next() {
-            Some(LuaTableEntry::KeyValue(key, value)) => {
+            Some(LuaTableEntry::KeyValue(b)) => {
+                let (key, value) = *b;
                 self.value = Some(value);
 
                 let key_de = MapKeyDeserializer::KeyValue(key);
                 seed.deserialize(key_de).map(Some)
             }
-            Some(LuaTableEntry::NameValue(key, value)) => {
+            Some(LuaTableEntry::NameValue(b)) => {
+                let (key, value) = *b;
                 self.value = Some(value);
                 let key_de = MapKeyDeserializer::NameValue(key);
                 seed.deserialize(key_de).map(Some)
             }
             Some(LuaTableEntry::Value(value)) => {
-                self.value = Some(value);
+                self.value = Some(*value);
+                let key_de = MapKeyDeserializer::Value(self.next_numeric_index);
+                self.next_numeric_index += 1;
+                seed.deserialize(key_de).map(Some)
+            }
+            Some(LuaTableEntry::NumberValue(value)) => {
+                self.value = Some(LuaValue::Number(value));
                 let key_de = MapKeyDeserializer::Value(self.next_numeric_index);
                 self.next_numeric_index += 1;
                 seed.deserialize(key_de).map(Some)
@@ -769,8 +785,14 @@ where
         V: Visitor<'de>,
     {
         let (variant, value) = match self.0.next() {
-            Some(LuaTableEntry::KeyValue(LuaValue::String(k), v)) => (k, v),
-            Some(LuaTableEntry::NameValue(k, v)) => (to_utf8_cow(k), v),
+            Some(LuaTableEntry::KeyValue(b)) if matches!(&b.0, LuaValue::String(_)) => {
+                let (k, v) = *b;
+                let LuaValue::String(k) = k else {
+                    unreachable!();
+                };
+                (k, v)
+            }
+            Some(LuaTableEntry::NameValue(b)) => (to_utf8_cow(b.0), b.1),
             _ => {
                 return Err(serde::de::Error::invalid_value(
                     Unexpected::Map,

--- a/serde_luaq/src/peg_parser.rs
+++ b/serde_luaq/src/peg_parser.rs
@@ -441,6 +441,11 @@ peg::parser! {
 
         rule table_entry(max_depth: u16) -> LuaTableEntry<'input>
             = _ v:(
+                // 1234
+                val:numbers() {
+                    LuaTableEntry::NumberValue(val)
+                } /
+
                 // "foo"
                 val:lua_value(max_depth)
                 {

--- a/serde_luaq/src/peg_parser.rs
+++ b/serde_luaq/src/peg_parser.rs
@@ -444,20 +444,20 @@ peg::parser! {
                 // "foo"
                 val:lua_value(max_depth)
                 {
-                    LuaTableEntry::Value(val)
+                    LuaTableEntry::Value(Box::new(val))
                 } /
 
                 // ["foo"]="bar"
                 // [1234]="bar"
                 "[" key:lua_value(max_depth) _ "]" _ "=" _ val:lua_value(max_depth)
                 {
-                    LuaTableEntry::KeyValue(key, val)
+                    LuaTableEntry::KeyValue(Box::new((key, val)))
                 } /
 
                 // foo = "bar"
                 key:identifier() _ "=" _ val:lua_value(max_depth)
                 {
-                    LuaTableEntry::NameValue(Cow::Borrowed(key), val)
+                    LuaTableEntry::NameValue(Box::new((Cow::Borrowed(key), val)))
                 } /
 
                 expected!("Lua table entry")

--- a/serde_luaq/src/peg_parser.rs
+++ b/serde_luaq/src/peg_parser.rs
@@ -411,6 +411,12 @@ peg::parser! {
                 longer_string(4) /
                 longer_string(5)
 
+        rule boolean() -> bool
+            = (
+                "true" { true } /
+                "false" { false }
+            )
+
         /// Parse a bare Lua value expression as a [`LuaValue`].
         ///
         /// The value _may_ be preceeded or followed by whitespace.
@@ -431,8 +437,7 @@ peg::parser! {
         pub rule lua_value(max_depth: u16) -> LuaValue<'input>
             = _ v:(
                 "nil" { LuaValue::Nil } /
-                "true" { LuaValue::Boolean(true) } /
-                "false" { LuaValue::Boolean(false) } /
+                b:boolean() { LuaValue::Boolean(b) } /
                 n:numbers() { LuaValue::Number(n) } /
                 s:string() { LuaValue::String(s) } /
                 t:table(max_depth) { LuaValue::Table(t) } /
@@ -441,6 +446,22 @@ peg::parser! {
 
         rule table_entry(max_depth: u16) -> LuaTableEntry<'input>
             = _ v:(
+                // foo = "bar"
+                key:identifier() _ "=" _ val:lua_value(max_depth)
+                {
+                    LuaTableEntry::NameValue(Box::new((Cow::Borrowed(key), val)))
+                } /
+
+                // nil
+                "nil" {
+                    LuaTableEntry::NilValue
+                } /
+
+                // true or false
+                val:boolean() {
+                    LuaTableEntry::BooleanValue(val)
+                } /
+
                 // 1234
                 val:numbers() {
                     LuaTableEntry::NumberValue(val)
@@ -457,12 +478,6 @@ peg::parser! {
                 "[" key:lua_value(max_depth) _ "]" _ "=" _ val:lua_value(max_depth)
                 {
                     LuaTableEntry::KeyValue(Box::new((key, val)))
-                } /
-
-                // foo = "bar"
-                key:identifier() _ "=" _ val:lua_value(max_depth)
-                {
-                    LuaTableEntry::NameValue(Box::new((Cow::Borrowed(key), val)))
                 } /
 
                 expected!("Lua table entry")

--- a/serde_luaq/src/serde_json.rs
+++ b/serde_luaq/src/serde_json.rs
@@ -164,12 +164,25 @@ pub fn to_json_value(
                     }
 
                     LuaTableEntry::Value(v) => {
+                        let v = to_json_value(*v, opts)?;
                         if object.is_empty() {
                             // We have no object yet, push into array
-                            array.push(to_json_value(*v, opts)?);
+                            array.push(v);
                         } else {
                             // We have an object, use the next key
-                            object.insert(array_next_idx.to_string(), to_json_value(*v, opts)?);
+                            object.insert(array_next_idx.to_string(), v);
+                            array_next_idx += 1;
+                        }
+                    }
+                    
+                    LuaTableEntry::NumberValue(n) => {
+                        let v = JsonNumber::try_from(n).map(JsonValue::Number)?;
+                        if object.is_empty() {
+                            // We have no object yet, push into array
+                            array.push(v);
+                        } else {
+                            // We have an object, use the next key
+                            object.insert(array_next_idx.to_string(), v);
                             array_next_idx += 1;
                         }
                     }

--- a/serde_luaq/src/serde_json.rs
+++ b/serde_luaq/src/serde_json.rs
@@ -134,11 +134,11 @@ pub fn to_json_value(
 
             for entry in items {
                 match entry {
-                    LuaTableEntry::KeyValue(k, v) => {
+                    LuaTableEntry::KeyValue(b) => {
                         // Switched to an object, move any existing entries from the array.
                         move_array_to_object(&mut array, &mut array_next_idx, &mut object);
 
-                        let k = match k {
+                        let k = match b.0 {
                             LuaValue::String(k) => if opts.lossy_string {
                                 from_utf8_cow_lossy(k)
                             } else {
@@ -153,23 +153,23 @@ pub fn to_json_value(
                             }
                         };
 
-                        object.insert(k, to_json_value(v, opts)?);
+                        object.insert(k, to_json_value(b.1, opts)?);
                     }
 
-                    LuaTableEntry::NameValue(k, v) => {
+                    LuaTableEntry::NameValue(b) => {
                         // Switched to an object, move any existing entries from the array.
                         move_array_to_object(&mut array, &mut array_next_idx, &mut object);
 
-                        object.insert(k.to_string(), to_json_value(v, opts)?);
+                        object.insert(b.0.to_string(), to_json_value(b.1, opts)?);
                     }
 
                     LuaTableEntry::Value(v) => {
                         if object.is_empty() {
                             // We have no object yet, push into array
-                            array.push(to_json_value(v, opts)?);
+                            array.push(to_json_value(*v, opts)?);
                         } else {
                             // We have an object, use the next key
-                            object.insert(array_next_idx.to_string(), to_json_value(v, opts)?);
+                            object.insert(array_next_idx.to_string(), to_json_value(*v, opts)?);
                             array_next_idx += 1;
                         }
                     }

--- a/serde_luaq/src/serde_json.rs
+++ b/serde_luaq/src/serde_json.rs
@@ -174,9 +174,33 @@ pub fn to_json_value(
                             array_next_idx += 1;
                         }
                     }
-                    
+
                     LuaTableEntry::NumberValue(n) => {
                         let v = JsonNumber::try_from(n).map(JsonValue::Number)?;
+                        if object.is_empty() {
+                            // We have no object yet, push into array
+                            array.push(v);
+                        } else {
+                            // We have an object, use the next key
+                            object.insert(array_next_idx.to_string(), v);
+                            array_next_idx += 1;
+                        }
+                    }
+
+                    LuaTableEntry::BooleanValue(b) => {
+                        let v = JsonValue::Bool(b);
+                        if object.is_empty() {
+                            // We have no object yet, push into array
+                            array.push(v);
+                        } else {
+                            // We have an object, use the next key
+                            object.insert(array_next_idx.to_string(), v);
+                            array_next_idx += 1;
+                        }
+                    }
+
+                    LuaTableEntry::NilValue => {
+                        let v = JsonValue::Null;
                         if object.is_empty() {
                             // We have no object yet, push into array
                             array.push(v);

--- a/serde_luaq/tests/identifiers.rs
+++ b/serde_luaq/tests/identifiers.rs
@@ -86,157 +86,157 @@ fn keywords() -> Result {
 
     // Keywords used as table key in strings should be accepted.
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"and".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"and\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"break".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"break\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"do".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"do\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"else".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"else\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"elseif".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"elseif\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"end".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"end\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"false".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"false\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"for".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"for\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"function".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"function\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"goto".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"goto\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"if".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"if\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"in".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"in\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"local".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"local\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"nil".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"nil\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"not".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"not\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"or".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"or\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"repeat".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"repeat\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"return".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"return\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"then".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"then\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"true".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"true\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"until".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"until\"] = true}", MAX_DEPTH)?,
     );
     assert_eq!(
-        LuaValue::Table(vec![LuaTableEntry::KeyValue(
+        LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
             b"while".into(),
             LuaValue::Boolean(true)
-        ),]),
+        ))),]),
         lua_value(b"{[\"while\"] = true}", MAX_DEPTH)?,
     );
 

--- a/serde_luaq/tests/json.rs
+++ b/serde_luaq/tests/json.rs
@@ -4,7 +4,7 @@ use crate::common::MAX_DEPTH;
 use serde_json::json;
 use serde_luaq::{
     from_json_value, lua_value, to_json_value, JsonConversionError, JsonConversionOptions,
-    LuaTableEntry, LuaValue,
+    LuaNumber, LuaTableEntry, LuaValue,
 };
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -53,10 +53,10 @@ fn table_coersion() -> Result {
     );
     assert_eq!(
         LuaValue::Table(vec![
-            LuaTableEntry::Value(LuaValue::integer(1)),
-            LuaTableEntry::Value(LuaValue::integer(2)),
-            LuaTableEntry::Value(LuaValue::integer(3)),
-            LuaTableEntry::Value(LuaValue::integer(4)),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(1)),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(2)),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(3)),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(4)),
         ]),
         from_json_value(json!([1, 2, 3, 4]))?,
     );
@@ -79,10 +79,22 @@ fn table_coersion() -> Result {
     // JSON keys are always str, and all keys are not valid identifiers
     assert_eq!(
         LuaValue::Table(vec![
-            LuaTableEntry::KeyValue(LuaValue::String(b"1".into()), LuaValue::integer(1)),
-            LuaTableEntry::KeyValue(LuaValue::String(b"2".into()), LuaValue::integer(2)),
-            LuaTableEntry::KeyValue(LuaValue::String(b"3".into()), LuaValue::integer(3)),
-            LuaTableEntry::KeyValue(LuaValue::String(b"4".into()), LuaValue::integer(4)),
+            LuaTableEntry::KeyValue(Box::new((
+                LuaValue::String(b"1".into()),
+                LuaValue::integer(1)
+            ))),
+            LuaTableEntry::KeyValue(Box::new((
+                LuaValue::String(b"2".into()),
+                LuaValue::integer(2)
+            ))),
+            LuaTableEntry::KeyValue(Box::new((
+                LuaValue::String(b"3".into()),
+                LuaValue::integer(3)
+            ))),
+            LuaTableEntry::KeyValue(Box::new((
+                LuaValue::String(b"4".into()),
+                LuaValue::integer(4)
+            ))),
         ]),
         from_json_value(json!({"1": 1, "2": 2, "3": 3, "4": 4}))?,
     );
@@ -97,11 +109,14 @@ fn table_coersion() -> Result {
     // Valid identifiers should be NameValue
     assert_eq!(
         LuaValue::Table(vec![
-            LuaTableEntry::KeyValue(LuaValue::String(b"5".into()), LuaValue::integer(5)),
-            LuaTableEntry::NameValue("a".into(), LuaValue::integer(1)),
-            LuaTableEntry::NameValue("b".into(), LuaValue::integer(2)),
-            LuaTableEntry::NameValue("c".into(), LuaValue::integer(3)),
-            LuaTableEntry::NameValue("d".into(), LuaValue::integer(4)),
+            LuaTableEntry::KeyValue(Box::new((
+                LuaValue::String(b"5".into()),
+                LuaValue::integer(5)
+            ))),
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::integer(1)))),
+            LuaTableEntry::NameValue(Box::new(("b".into(), LuaValue::integer(2)))),
+            LuaTableEntry::NameValue(Box::new(("c".into(), LuaValue::integer(3)))),
+            LuaTableEntry::NameValue(Box::new(("d".into(), LuaValue::integer(4)))),
         ]),
         from_json_value(json!({"5": 5, "a": 1, "b": 2, "c": 3, "d": 4}))?,
     );

--- a/serde_luaq/tests/strings.rs
+++ b/serde_luaq/tests/strings.rs
@@ -135,10 +135,10 @@ fn long_string() -> Result {
     check(
         b"{[[hello]],[=[world]=],'!',\"?\"}",
         LuaValue::Table(vec![
-            LuaTableEntry::Value(LuaValue::String(b"hello".into())),
-            LuaTableEntry::Value(LuaValue::String(b"world".into())),
-            LuaTableEntry::Value(LuaValue::String(b"!".into())),
-            LuaTableEntry::Value(LuaValue::String(b"?".into())),
+            LuaTableEntry::Value(Box::new(LuaValue::String(b"hello".into()))),
+            LuaTableEntry::Value(Box::new(LuaValue::String(b"world".into()))),
+            LuaTableEntry::Value(Box::new(LuaValue::String(b"!".into()))),
+            LuaTableEntry::Value(Box::new(LuaValue::String(b"?".into()))),
         ]),
     );
 

--- a/serde_luaq/tests/tables.rs
+++ b/serde_luaq/tests/tables.rs
@@ -101,6 +101,20 @@ fn tables() {
         LuaValue::Table(vec![LuaValue::Nil.into(), true.into(), false.into()]),
     );
 
+    // Keys with booleanish names
+    let b = b"{nil, nilth = 1, true, truer = 2, false, falsey = 3}";
+    check(
+        b,
+        LuaValue::Table(vec![
+            LuaTableEntry::NilValue,
+            LuaTableEntry::NameValue(Box::new(("nilth".into(), LuaValue::integer(1)))),
+            LuaTableEntry::BooleanValue(true),
+            LuaTableEntry::NameValue(Box::new(("truer".into(), LuaValue::integer(2)))),
+            LuaTableEntry::BooleanValue(false),
+            LuaTableEntry::NameValue(Box::new(("falsey".into(), LuaValue::integer(3)))),
+        ]),
+    );
+
     // Example on https://www.lua.org/manual/5.4/manual.html#3.4.9, without function calls
     let b = b"{ [9999] = \"g\"; 'x', \"y\"; x = 1, 9999, [30] = 23; 45 }";
     check(

--- a/serde_luaq/tests/tables.rs
+++ b/serde_luaq/tests/tables.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use crate::common::{check, should_error, MAX_DEPTH};
-use serde_luaq::{LuaNumber, LuaTableEntry, LuaValue, lua_value, script};
+use serde_luaq::{lua_value, script, LuaNumber, LuaTableEntry, LuaValue};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -95,15 +95,21 @@ fn tables() {
     check(b, LuaValue::Table(vec![]));
 
     // Object containing nil
-    let b = b"{nil}";
-    check(b, LuaValue::Table(vec![LuaValue::Nil.into()]));
+    let b = b"{nil, true, false}";
+    check(
+        b,
+        LuaValue::Table(vec![LuaValue::Nil.into(), true.into(), false.into()]),
+    );
 
     // Example on https://www.lua.org/manual/5.4/manual.html#3.4.9, without function calls
     let b = b"{ [9999] = \"g\"; 'x', \"y\"; x = 1, 9999, [30] = 23; 45 }";
     check(
         b,
         LuaValue::Table(vec![
-            LuaTableEntry::KeyValue(Box::new((LuaValue::integer(9999), LuaValue::String(b"g".into())))),
+            LuaTableEntry::KeyValue(Box::new((
+                LuaValue::integer(9999),
+                LuaValue::String(b"g".into()),
+            ))),
             LuaValue::String(b"x".into()).into(),
             LuaValue::String(b"y".into()).into(),
             LuaTableEntry::NameValue(Box::new(("x".into(), LuaValue::integer(1)))),
@@ -190,7 +196,9 @@ fn long_string_tables() -> Result {
     check(b"{[ [[a]] ] = [[b]]}", &expected);
 
     // Deceptive syntax
-    let expected = LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::String(b"[a".into())))]);
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::String(
+        b"[a".into(),
+    )))]);
     check(b"{[[[a]]}", &expected);
     check(b"{[=[[a]=]}", &expected);
 

--- a/serde_luaq/tests/tables.rs
+++ b/serde_luaq/tests/tables.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use crate::common::{check, should_error, MAX_DEPTH};
-use serde_luaq::{lua_value, script, LuaTableEntry, LuaValue};
+use serde_luaq::{LuaNumber, LuaTableEntry, LuaValue, lua_value, script};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -17,18 +17,18 @@ fn simple_table() -> Result {
         br#"{["int"]=1,["seq"]={"a", "b", x3yz = 0x12, ["foo"] = "bar", [5] = 42, [0xa] = 3.14}}"#;
 
     let expected = LuaValue::Table(vec![
-        LuaTableEntry::KeyValue(b"int".into(), LuaValue::integer(1)),
-        LuaTableEntry::KeyValue(
+        LuaTableEntry::KeyValue(Box::new((b"int".into(), LuaValue::integer(1)))),
+        LuaTableEntry::KeyValue(Box::new((
             b"seq".into(),
             LuaValue::Table(vec![
-                LuaTableEntry::Value(LuaValue::String(b"a".into())),
-                LuaTableEntry::Value(LuaValue::String(b"b".into())),
-                LuaTableEntry::NameValue("x3yz".into(), 0x12.into()),
-                LuaTableEntry::KeyValue(b"foo".into(), b"bar".into()),
-                LuaTableEntry::KeyValue(5.into(), 42.into()),
-                LuaTableEntry::KeyValue(0xa.into(), 3.14.into()),
+                LuaTableEntry::Value(Box::new(LuaValue::String(b"a".into()))),
+                LuaTableEntry::Value(Box::new(LuaValue::String(b"b".into()))),
+                LuaTableEntry::NameValue(Box::new(("x3yz".into(), 0x12.into()))),
+                LuaTableEntry::KeyValue(Box::new((b"foo".into(), b"bar".into()))),
+                LuaTableEntry::KeyValue(Box::new((5.into(), 42.into()))),
+                LuaTableEntry::KeyValue(Box::new((0xa.into(), 3.14.into()))),
             ]),
-        ),
+        ))),
     ]);
 
     let actual = lua_value(data, MAX_DEPTH)?;
@@ -68,12 +68,12 @@ fn simple_table() -> Result {
         (
             "seq",
             LuaValue::Table(vec![
-                LuaTableEntry::Value(LuaValue::String(b"a".into())),
-                LuaTableEntry::Value(LuaValue::String(b"b".into())),
-                LuaTableEntry::NameValue("x3yz".into(), 0x12.into()),
-                LuaTableEntry::KeyValue(b"foo".into(), b"bar".into()),
-                LuaTableEntry::KeyValue(5.into(), 42.into()),
-                LuaTableEntry::KeyValue(0xa.into(), 3.14.into()),
+                LuaValue::String(b"a".into()).into(),
+                LuaValue::String(b"b".into()).into(),
+                LuaTableEntry::NameValue(Box::new(("x3yz".into(), 0x12.into()))),
+                LuaTableEntry::KeyValue(Box::new((b"foo".into(), b"bar".into()))),
+                LuaTableEntry::KeyValue(Box::new((5.into(), 42.into()))),
+                LuaTableEntry::KeyValue(Box::new((0xa.into(), 3.14.into()))),
             ]),
         ),
     ];
@@ -103,13 +103,13 @@ fn tables() {
     check(
         b,
         LuaValue::Table(vec![
-            LuaTableEntry::KeyValue(LuaValue::integer(9999), LuaValue::String(b"g".into())),
+            LuaTableEntry::KeyValue(Box::new((LuaValue::integer(9999), LuaValue::String(b"g".into())))),
             LuaValue::String(b"x".into()).into(),
             LuaValue::String(b"y".into()).into(),
-            LuaTableEntry::NameValue("x".into(), LuaValue::integer(1)),
-            LuaTableEntry::Value(LuaValue::integer(9999)),
-            LuaTableEntry::KeyValue(LuaValue::integer(30), LuaValue::integer(23)),
-            LuaTableEntry::Value(LuaValue::integer(45)),
+            LuaTableEntry::NameValue(Box::new(("x".into(), LuaValue::integer(1)))),
+            LuaNumber::Integer(9999).into(),
+            LuaTableEntry::KeyValue(Box::new((LuaValue::integer(30), LuaValue::integer(23)))),
+            LuaNumber::Integer(45).into(),
         ]),
     );
 }
@@ -126,29 +126,39 @@ fn recursion() -> Result {
 
     check(
         b,
-        LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::Table(vec![
-            LuaTableEntry::Value(LuaValue::Table(vec![LuaTableEntry::Value(
-                LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::Table(vec![
-                    LuaTableEntry::Value(LuaValue::Table(vec![LuaTableEntry::Value(
-                        LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::Table(vec![
-                            LuaTableEntry::Value(LuaValue::Table(vec![LuaTableEntry::Value(
-                                LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::Table(vec![
-                                    LuaTableEntry::Value(LuaValue::Table(vec![
-                                        LuaTableEntry::Value(LuaValue::Table(vec![
-                                            LuaTableEntry::Value(LuaValue::Table(vec![
-                                                LuaTableEntry::Value(LuaValue::Table(vec![
-                                                    LuaTableEntry::Value(LuaValue::Table(vec![])),
-                                                ])),
-                                            ])),
-                                        ])),
-                                    ])),
-                                ]))]),
-                            )])),
-                        ]))]),
-                    )])),
-                ]))]),
-            )])),
-        ]))]),
+        LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+            LuaTableEntry::Value(Box::new(LuaValue::Table(vec![LuaTableEntry::Value(
+                Box::new(LuaValue::Table(vec![LuaTableEntry::Value(Box::new(
+                    LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                        LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                            LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                                LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                                    LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                                        LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                                            LuaTableEntry::Value(Box::new(LuaValue::Table(vec![
+                                                LuaTableEntry::Value(Box::new(LuaValue::Table(
+                                                    vec![LuaTableEntry::Value(Box::new(
+                                                        LuaValue::Table(vec![
+                                                            LuaTableEntry::Value(Box::new(
+                                                                LuaValue::Table(vec![
+                                                                    LuaTableEntry::Value(Box::new(
+                                                                        LuaValue::Table(vec![]),
+                                                                    )),
+                                                                ]),
+                                                            )),
+                                                        ]),
+                                                    ))],
+                                                ))),
+                                            ]))),
+                                        ]))),
+                                    ]))),
+                                ]))),
+                            ]))),
+                        ]))),
+                    ])))]),
+                ))])),
+            )]))),
+        ])))]),
     );
 
     let b = b"{{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}}";
@@ -170,29 +180,29 @@ fn recursion() -> Result {
 fn long_string_tables() -> Result {
     // When a long string is used as a table key, there must be a space before
     // the long string.
-    let expected = LuaValue::Table(vec![LuaTableEntry::KeyValue(
+    let expected = LuaValue::Table(vec![LuaTableEntry::KeyValue(Box::new((
         LuaValue::String(b"a".into()),
         LuaValue::String(b"b".into()),
-    )]);
+    )))]);
     check(b"{[ [[a]]]=[[b]]}", &expected);
     check(b"{[ [=[a]=]]=[[b]]}", &expected);
     check(b"{[ [[a]]] = [[b]]}", &expected);
     check(b"{[ [[a]] ] = [[b]]}", &expected);
 
     // Deceptive syntax
-    let expected = LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::String(b"[a".into()))]);
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::String(b"[a".into())))]);
     check(b"{[[[a]]}", &expected);
     check(b"{[=[[a]=]}", &expected);
 
-    let expected = LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::String(
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::String(
         b"=[a]=".into(),
-    ))]);
+    )))]);
     check(b"{[[=[a]=]]}", &expected);
     check(b"{[==[=[a]=]==]}", &expected);
 
-    let expected = LuaValue::Table(vec![LuaTableEntry::Value(LuaValue::String(
+    let expected = LuaValue::Table(vec![LuaTableEntry::Value(Box::new(LuaValue::String(
         b"[a] = [[foo".into(),
-    ))]);
+    )))]);
     check(b"{[[[a] = [[foo]]}", &expected);
     check(b"{[=[[a] = [[foo]=]}", &expected);
 


### PR DESCRIPTION
On `aarch64`, `LuaTableEntry` was using a minimum of 64 bytes (2x `LuaValue`). With this change, it uses a minimum of 16 bytes.

In addition to `Box`ing up the larger variants, this also adds `LuaNumber`, `bool` and `nil` variants of `LuaTableEntry::Value` (bare values), which allow these smaller variants to avoid a heap allocation.

There is a net _increase_ in memory usage for the `KeyValue` variant (was 64 bytes, now 80 bytes).

Unfortunately, this makes some variants clunkier to use, until we can have [deref patterns](https://doc.rust-lang.org/beta/unstable-book/language-features/deref-patterns.html).