### PR TITLE
Test unicode field names with Serde, implement more PartialEq, check sizes, more doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ source code with Lua... but this is not currently measured.
 
   The goal is that these will be answered by the documentation.
 
-Issues and questions sent by email will attract my professional consulting rates. :)
+Issues and questions sent by email may attract my professional consulting rates. :)
 
 ## Submitting PRs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
+ "static_assertions",
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -442,6 +443,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ that a JSON parser would implement:
 - [x] `nil`
 - [x] Booleans (`true`, `false`)
 - [x] [Numbers][lua3.1]
-  - [x] [Integers][lua3.1]
+  - [x] [Integers][lua3.1] (`i64` only)
     - [x] Decimal integers (`123`)
       - [x] Coercion to float for decimal numbers `< i64::MIN` or `> i64::MAX` ([Lua 5.4][lua8])
-    - [x] Hexadecimal integer (`0xFF`)
+    - [x] Hexadecimal integers (`0xFF`)
       - [x] Wrapping large hexadecimal numbers to `i64`
-  - [x] [Floats][lua3.1]
+  - [x] [Floats][lua3.1] (`f64` only)
     - [x] Decimal floats with decimal point and optional exponent (`3.14`, `0.314e1`)
     - [x] Decimal floats with mandatory exponent (`3e14`)
     - [x] Hexadecimal floating points (`0x.ABCDEFp+24`) (*not supported on WASM*)
@@ -130,12 +130,12 @@ are _intentionally unsupported_:
 
 - Arithmetic operators (`+`, `-`, `*`, `/`...)
 - Bitwise operators (`<<`, `>>`, `&`, `|`, `~`...)
-- Blocks and visibility modifiers (`do ... end`, `local`)
+- Blocks and control structures (`if`, `break`, `do`, `end`, `for`, `goto`, `repeat`, `until`, `while`...)
 - Comments
-- Control structures (`if`, `break`, `for`, `goto`, `repeat`, `until`, `while`...)
 - Function calls
 - Function definitions
 - Length operator (`#`)
+- Locale-specific behaviour (`3,14159`)
 - Logical operators (`and`, `or`, `not`)
 - Newline character normalisation in strings (`\r\n` => `\n` on UNIX, `\n` => `\r\n` on Windows)
 - Parentheses, except for `(0/0)` (NaN)
@@ -147,6 +147,7 @@ are _intentionally unsupported_:
 - Updating other variables (`a = {}; a.b = 'foo'`)
 - Userdata
 - Vararg assignments and destructuring (`a, b = 1, 2`)
+- Variable attributes and visibility modifiers (`local <const> a = 10`)
 
 If you want to use these language features or otherwise need to run arbitrary Lua code, look at
 something like [`mlua`][mlua], which links to `liblua`, and also provides `serde` bindings.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ The goal is to be able to read state from software (mostly games) which is seria
 
 This library consists of four parts:
 
-- A [`LuaValue`][luavalue] `enum`, which describes Lua 5.4's basic data types (`nil`, boolean, string, number,
-  table).
+- A [`LuaValue`][luavalue] `enum`, which describes Lua 5.4's basic data types (`nil`, boolean,
+  string, number, table).
 
 - A [`peg`][peg]-based parser for parsing a `&[u8]` (containing Lua) into a `LuaValue`.
 
-- A [`serde`][serde]-based `Deserialize` implementation for converting a `LuaValue` into your own
+- A [Serde][serde]-based `Deserialize` implementation for converting a `LuaValue` into your own
   data types.
 
 - _Optional_ lossy converter to and from `serde_json`'s `Value` type.

--- a/serde_luaq/Cargo.toml
+++ b/serde_luaq/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = ["dep:serde_json"]
 peg = "0.8.5"
 serde = "1.0.210"
 serde_json = { version = "1.0.138", optional = true }
+static_assertions = "1.1.0"
 thiserror = "1.0.63"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/serde_luaq/README.md
+++ b/serde_luaq/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/serde_luaq/src/lib.rs
+++ b/serde_luaq/src/lib.rs
@@ -459,7 +459,8 @@
 //!
 //! At present, the highest-known memory usage per byte of input Lua is a deeply-nested table of
 //! tables, which consumes about 96 bytes of RAM for 2 bytes of input Lua (ie: 48&times;) on a
-//! 64-bit system. This means a 64 MiB input could use up to 3 GiB of RAM.
+//! 64-bit system. This means a 64 MiB input could use up to 3 GiB of RAM. This can be mitigated by
+//! [lowering the maximum table depth](#maximum-table-depth).
 //!
 //! Lua uses similar amounts of memory for such data structures.
 //!

--- a/serde_luaq/src/lib.rs
+++ b/serde_luaq/src/lib.rs
@@ -95,6 +95,9 @@
 //! * locale-dependant behaviour
 //! * platform-dependant behaviour
 //!
+//! Unicode identifiers (`LUA_UCID`) and other locale-specific identifiers are not supported, even
+//! if they would be valid in Rust.
+//!
 //! ### Numbers
 //!
 //! `serde_luaq` follows Lua 5.4's number handling semantics, but _doesn't_ implement
@@ -122,17 +125,23 @@
 //! * Decimal integer literals _outside_ of the [`i64`][] range are converted to [`f64`][], and will
 //!   lose precision. These cannot be used with [`i64`][] fields.
 //!
-//! * Hexadecimal integer literals _outside_ of the [`i64`][] range will under/overflow as
-//!   [`i64`][], even in [`f64`][] fields (ie: `0xffffffffffffffff` is `-1_f64`), and can _always_
-//!   be used with [`i64`][] fields.
+//! * Hexadecimal integer literals are always coerced to [`i64`][], and can _always_ be used with
+//!   [`i64`][] fields. Values _outside_ of the [`i64`][] range will _only_ under/overflow as
+//!   [`i64`][], regardless of the field type.
 //!
-//! * Unsigned integer fields like [`u8`][] and [`u16`][] reject all negative integer literals,
-//!   including hexadecimal integer literals.
+//!   This means the literal `0xffffffffffffffff` is always treated as if it were written `-1`, even
+//!   for [`f64`][], [`i8`][], and [`u64`][] fields. This would be an error for unsigned types.
 //!
-//! * Narrower integer fields like [`i8`][] and [`i16`][] reject all integer literals outside of
-//!   their range, including hexadecimal integer literals.
+//! * Narrower integer fields like [`i8`][] and [`i16`][] reject all integer literals that are
+//!   outside of their range.
 //!
-//! * Narrower float fields like [`f32`][] are first handled as a [`f64`][] then converted to
+//!   The [`i64`][] coersion process means that the hexadecimal literal `0xff` is treated as if it
+//!   were written `255`, and using it with an [`i8`][] field would be an error.
+//!
+//! * Unsigned integer fields like [`u8`][] and [`u16`][] reject all negative decimal integer
+//!   literals.
+//!
+//! * Narrower float fields like [`f32`][] are first handled as a [`f64`][], then converted to
 //!   [`f32`][]. This will result in a loss of precision, and values outside of
 //!   [their acceptable range][f32::MAX] will be set to [positive][f32::INFINITY] or
 //!   [negative infinity][f32::NEG_INFINITY].
@@ -151,7 +160,8 @@
 //!
 //! Lua's `\u{...}` escapes follow [RFC 2279][] (1998) rather than [RFC 3629][] (2003). RFC 2279
 //! differs by allowing [surrogate code points][surrogate] and code points greater than
-//! `\u{10FFFF}`. `serde_luaq` will convert these escapes into bytes following RFC 2279.
+//! `\u{10FFFF}`. `serde_luaq` will convert these escapes into bytes following RFC 2279, which might
+//! not be valid in RFC 3629.
 //!
 //! Serde [`String`] fields can be used the string literal evaluates to valid RFC 3629 UTF-8. This
 //! is not guaranteed even if [the input data is `&str`][self::from_str], as Lua string escapes may
@@ -165,7 +175,17 @@
 //! Lua tables are used for both lists and maps.
 //!
 //! The [`peg` deserialisers](#peg-deserialiser) will always produce a [`Vec`][] of
-//! [`LuaTableEntry`][] in the order the entries were defined, including duplicate keys.
+//! [`LuaTableEntry`][] in the order the entries were defined. It does not attempt to reconcile
+//! implicit keys mixed with explicit keys, nor duplicate keys.
+//!
+//! Unlike Lua, a [`LuaTableEntry`][] may use _any_ key or value type, including
+//! [`nil`][LuaValue::Nil] and [NaN][f64::NAN].
+//!
+//! As a convienience, [identifier-keyed entries][LuaTableEntry::NameValue] (`{ a = 1 }`) are
+//! treated as keyed with [`str`][], because with Lua's default build settings, these are always
+//! valid [RFC 3629][] UTF-8.
+//!
+//! The rules are slightly different when using Serde, which is described below.
 //!
 //! #### Duplicate table keys in Serde
 //!
@@ -183,28 +203,117 @@
 //! #### Tables as lists in Serde (Vec)
 //!
 //! Lua tables are 1-indexed, rather than 0-indexed. `serde_luaq` will handle these differences on
-//! the input side for explicitly-keyed values, and make the resulting [`Vec`] 0-indexed.
+//! the input side for explicitly-keyed values, and make the resulting [`Vec`] 0-indexed:
 //!
-//! Table entries may be defined with implicit or explicit keys, or a combination. Any missing
-//! entries will be treated as `nil`:
+//! ```rust
+//! # use serde::Deserialize;
+//! # use serde_luaq::{Error, LuaFormat, from_slice};
+//! # fn main() -> Result<(), Error> {
+//! let a: Vec<i64> = from_slice(
+//!     b"{1, 2, 3}",
+//!     LuaFormat::Value,
+//!     /* max table depth */ 16,
+//! )?;
 //!
-//! ```text
-//! { 1, [3] = 2 } == vec![Some(1), None, Some(2)]
+//! assert_eq!(a[0], 1);
+//! assert_eq!(a[1], 2);
+//! assert_eq!(a[2], 3);
+//! # Ok(())
+//! # }
 //! ```
+//!
+//! Table entries may be defined with implicit or explicit keys, or a combination, and may be
+//! defined in any order.
+//!
+//! Any missing entries will be treated as `nil`, which can be used with [`Option`][]:
+//!
+//! ```rust
+//! # use serde::Deserialize;
+//! # use serde_luaq::{Error, LuaFormat, from_slice};
+//! # fn main() -> Result<(), Error> {
+//! let b: Vec<Option<i64>> = from_slice(
+//!     b"{1, [4] = 4, 2}",
+//!     LuaFormat::Value,
+//!     /* max table depth */ 16,
+//! )?;
+//!
+//! assert_eq!(b, vec![Some(1), Some(2), None, Some(4)]);
+//!
+//! let c: Vec<Option<i64>> = from_slice(
+//!     b"{1, [1000] = 1000}",
+//!     LuaFormat::Value,
+//!     /* max table depth */ 16,
+//! )?;
+//!
+//! assert_eq!(c.len(), 1000);
+//! assert_eq!(c[0], Some(1));
+//! assert_eq!(c[999], Some(1000));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! If you're working with a sparse table, it's probably better to handle it as a map (see below).
 //!
 //! #### Tables as maps in Serde (BTreeMap/HashMap)
 //!
 //! If the key of the map is an integer type, table entries may contain implicit keys. Like Lua,
 //! implicit keys start counting at 1, without regard for explicit keys.
 //!
+//! ```rust
+//! # use std::collections::BTreeMap;
+//! # use serde::Deserialize;
+//! # use serde_luaq::{Error, LuaFormat, from_slice};
+//! # fn main() -> Result<(), Error> {
+//! let a: BTreeMap<i64, i64> = from_slice(
+//!     b"{1, [4] = 4, 2}",
+//!     LuaFormat::Value,
+//!     /* max table depth */ 16,
+//! )?;
+//!
+//! assert_eq!(1, *a.get(&1).unwrap());
+//! assert_eq!(2, *a.get(&2).unwrap());
+//! assert_eq!(4, *a.get(&4).unwrap());
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! Otherwise, all entries must be explicitly keyed.
+//!
+//! For maps, `serde_luaq` treats "entry present and set to `nil`" and "entry not present" as
+//! distinct states. This means unless a key or value uses an [`Option`][] type, it must not contain
+//! `nil`:
+//!
+//! ```rust
+//! # use std::collections::BTreeMap;
+//! # use serde::Deserialize;
+//! # use serde_luaq::{Error, LuaFormat, from_slice};
+//! # fn main() -> Result<(), Error> {
+//! let input = b"{a = 1, b = nil}";
+//!
+//! // Error: b cannot be a unit (None) type
+//! assert!(from_slice::<BTreeMap<String, i64>>(input, LuaFormat::Value, 16).is_err());
+//!
+//! // Success: b is set to None, other entries are set to Some
+//! let a: BTreeMap<String, Option<i64>> = from_slice(input, LuaFormat::Value, 16)?;
+//! assert_eq!(Some(1), *a.get("a").unwrap());
+//! assert!(a.get("b").unwrap().is_none()); // present, set to nil
+//! assert!(a.get("c").is_none()); // not present
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! #### Tables as structs
 //!
 //! When deserialising a table as a `struct`, all keys must be valid [RFC 3629 strings](#strings) or
 //! [Lua identifiers][LuaTableEntry::NameValue].
 //!
-//! Unicode identifiers (`LUA_UCID`) and other locale-specific identifiers are not supported.
+//! Unicode identifiers (`LUA_UCID`) and other locale-specific identifiers are not supported, even
+//! if they would be valid Rust identifiers. If used in a table key, these must be written as a
+//! string instead:
+//!
+//! ```lua
+//! { english = "en", ["français"] = "fr" }
+//! ```
 //!
 //! [Serde does not support numeric keys in structs][serde-num-keys].
 //!
@@ -233,7 +342,67 @@
 //! * **Ravi** adds type annotations and some other language features, which aren't supported by
 //!   `serde_luaq`.
 //!
-//! ## Maximum table depth
+//! ## Security
+//!
+//! While using Lua as a serialisation format is convenient to work with in Lua,
+//! [its `load()`][load] and [`require()`][require] functions allow arbitrary code execution, so
+//! aren't safe to use with untrusted inputs. These risks are similar to using
+//! [JavaScript's `eval()` function][jseval] to load JSON data (instead of
+//! [`JSON.parse()`][jsonparse]).
+//!
+//! For example, this Lua function loads an expression in the string `data`, similar to what would
+//! be produced by [the `serialize()` function described in _Programming in Lua_][pil12.1.1]:
+//!
+//! ```lua
+//! -- WARNING: this function is insecure and unsafe.
+//! function deserialize(data)
+//!     data = "return (" .. data .. ")"
+//!     local f = load(data, nil, "t")
+//!     if f == nil then
+//!         return error("could not load data")
+//!     end
+//!     local status, r = pcall(f)
+//!     if not status then
+//!         return error("could not call data")
+//!     end
+//!     return r
+//! end
+//!
+//! a = deserialize("{hello='world'}")
+//! -- Prints "world"
+//! print(a.hello)
+//! ```
+//!
+//! If your program is ever sent untrusted Lua inputs, a malicious actor could insert some code
+//! which could do anything to your program or the system it is running on.
+//!
+//! For example, this input would cause it to read and return the contents of `/etc/passwd`:
+//!
+//! ```lua
+//! (function() f=io.open('/etc/passwd');return f:read('a');end)()
+//! ```
+//!
+//! `serde_luaq` addresses this risk by implementing a JSON-like subset of Lua's syntax, such that
+//! inserting code is a syntax error:
+//!
+//! ```rust
+//! use serde_luaq::{LuaValue, lua_value};
+//!
+//! // This would cause Lua to return the contents of a local file:
+//! let input = b"(function() f=io.open('/etc/passwd');return f:read('a');end)()";
+//! // But it's a syntax error here.
+//! assert!(lua_value(input, 16).is_err());
+//!
+//! // This would cause Lua to use a lot of RAM:
+//! let input = b"(function() x={};for a=1,100000000 do x[a]=a end;return x;end)()";
+//! // But it's a syntax error here.
+//! assert!(lua_value(input, 16).is_err());
+//! ```
+//!
+//! Ideally, [`serde_luaq` shouldn't use significantly more memory than Lua](#large-input-data) to
+//! read the same data structures. If it doesn't, that's a bug. :)
+//!
+//! ### Maximum table depth
 //!
 //! The maximum table depth argument (`max_depth`) controls how deeply nested a table can be before
 //! being rejected by `serde_luaq`. Set this to the maximum depth of tables that you expect in your
@@ -261,16 +430,47 @@
 //! <div class="warning">
 //!
 //! **Warning:** setting `max_depth` too high allows a heavily-nested table to cause your program
-//! [to overflow its stack and crash][stackoverflow]. What is "too high" depends on your platform
-//! and where you call `serde_luaq` in your program.
+//! [to overflow its stack and crash][stackoverflow], or use
+//! [a large amount of memory per byte of input Lua](#large-input-data).
+//!
+//! What is "too high" depends on your platform and where you call `serde_luaq` in your program.
 //!
 //! Setting `max_depth` to `0` disables support for tables, _even empty tables_.
 //!
 //! </div>
 //!
+//! ### Large input data
+//!
+//! `serde_luaq` requires that the entire input fit in memory, and be less than [`usize::MAX`][]
+//! bytes (4 GiB on 32-bit systems, 16 EiB on 64-bit systems). It is the _caller's_ responsibility
+//! to enforce a reasonable input size limit.
+//!
+//! When deserialising a Lua data structure on a 64-bit system, the _minimum_ sizes of the
+//! [`LuaValue`][] and [`LuaTableEntry`][] `enum`s are 32 and 16 bytes respectively. Values are
+//! checked at compile-time on `aarch64`, `wasm32` and `x86_64` targets to prevent regressions.
+//!
+//! Heap-allocated variants of these `enum`s (those with [`Cow`][std::borrow::Cow] or [`Vec`][]
+//! fields) will use more memory.
+//!
+//! `serde_luaq` uses [`Cow`][std::borrow::Cow] to avoid owning strings whenever possible, and
+//! borrow them from the input buffer instead. However, strings that contain escape sequences need
+//! to be copied, but this is _at worst_ 1 to 1 memory with input Lua plus [`Vec`][]'s usual
+//! overheads.
+//!
+//! At present, the highest-known memory usage per byte of input Lua is a deeply-nested table of
+//! tables, which consumes about 96 bytes of RAM for 2 bytes of input Lua (ie: 48&times;) on a
+//! 64-bit system. This means a 64 MiB input could use up to 3 GiB of RAM.
+//!
+//! Lua uses similar amounts of memory for such data structures.
+//!
 //! [comma]: https://github.com/lua/lua/blob/104b0fc7008b1f6b7d818985fbbad05cd37ee654/testes/literals.lua#L298-L300
 //! [format]: https://www.lua.org/manual/5.4/manual.html#pdf-string.format
 //! [`peg`]: https://docs.rs/peg/latest/peg/
+//! [jseval]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
+//! [jsonparse]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+//! [load]: https://www.lua.org/manual/5.4/manual.html#pdf-load
+//! [pil12.1.1]: https://www.lua.org/pil/12.1.1.html
+//! [require]: https://www.lua.org/manual/5.4/manual.html#pdf-require
 //! [Serde]: https://serde.rs/
 //! [serde_bytes]: https://docs.rs/serde_bytes/latest/serde_bytes/
 //! [serde-num-keys]: https://github.com/serde-rs/serde/issues/2358

--- a/serde_luaq/src/number/mod.rs
+++ b/serde_luaq/src/number/mod.rs
@@ -1,5 +1,6 @@
 mod de;
 
+use crate::LuaValue;
 use std::{fmt::Display, ops::Neg};
 
 /// Maximum integer value that can be represented in an [`f64`] without loss of precision.
@@ -173,6 +174,15 @@ impl Display for LuaNumber {
         match self {
             Self::Float(v) => v.fmt(f),
             Self::Integer(v) => v.fmt(f),
+        }
+    }
+}
+
+impl PartialEq<LuaValue<'_>> for LuaNumber {
+    fn eq(&self, other: &LuaValue<'_>) -> bool {
+        match other {
+            LuaValue::Number(n) => other == n,
+            _ => false,
         }
     }
 }

--- a/serde_luaq/src/number/mod.rs
+++ b/serde_luaq/src/number/mod.rs
@@ -1,6 +1,12 @@
 mod de;
 
 use crate::LuaValue;
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32"
+))]
+use static_assertions::assert_eq_size;
 use std::{fmt::Display, ops::Neg};
 
 /// Maximum integer value that can be represented in an [`f64`] without loss of precision.
@@ -24,6 +30,13 @@ pub enum LuaNumber {
     /// uses 64-bit values.
     Float(f64),
 }
+
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32",
+))]
+assert_eq_size!((i64, f64), LuaNumber);
 
 impl LuaNumber {
     /// Returns `true` if the value is NaN.

--- a/serde_luaq/src/table_entry.rs
+++ b/serde_luaq/src/table_entry.rs
@@ -11,7 +11,7 @@ use crate::{
 use static_assertions::assert_eq_size;
 use std::{borrow::Cow, str::from_utf8};
 
-/// Lua table entry.
+/// Lua [table][LuaValue::Table] entry.
 ///
 /// Reference: <https://www.lua.org/manual/5.4/manual.html#3.4.9>
 #[derive(Debug, Clone, PartialEq)]

--- a/serde_luaq/src/table_entry.rs
+++ b/serde_luaq/src/table_entry.rs
@@ -3,6 +3,12 @@ use crate::{
     value::{from_utf8_cow, to_utf8_cow},
     LuaNumber, LuaValue,
 };
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32",
+))]
+use static_assertions::assert_eq_size;
 use std::{borrow::Cow, str::from_utf8};
 
 /// Lua table entry.
@@ -52,6 +58,13 @@ pub enum LuaTableEntry<'a> {
     /// for `nil` literals that avoids an extra heap allocation.
     NilValue,
 }
+
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32",
+))]
+assert_eq_size!(LuaNumber, LuaTableEntry<'_>);
 
 impl<'a> LuaTableEntry<'a> {
     pub const fn implicit_key(&self) -> bool {

--- a/serde_luaq/src/value/mod.rs
+++ b/serde_luaq/src/value/mod.rs
@@ -499,6 +499,15 @@ pub(crate) fn to_utf8_cow(v: Cow<'_, str>) -> Cow<'_, [u8]> {
     }
 }
 
+impl PartialEq<LuaNumber> for LuaValue<'_> {
+    fn eq(&self, other: &LuaNumber) -> bool {
+        match self {
+            LuaValue::Number(n) => n == other,
+            _ => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -555,73 +564,105 @@ mod test {
     #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_integer() {
         // i64
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0));
-        assert_eq!(LuaValue::integer(i64::MIN), LuaValue::from(i64::MIN));
-        assert_eq!(LuaValue::integer(i64::MAX), LuaValue::from(i64::MAX));
+        for x in [0, i64::MIN, i64::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x), v);
+            assert_eq!(LuaValue::integer(x), LuaNumber::Integer(x));
+            assert_eq!(LuaNumber::Integer(x), LuaValue::integer(x));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
 
         // i32
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0i32));
-        assert_eq!(LuaValue::integer(i32::MIN.into()), LuaValue::from(i32::MIN));
-        assert_eq!(LuaValue::integer(i32::MAX.into()), LuaValue::from(i32::MAX));
+        for x in [0, i32::MIN, i32::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x.into()), v);
+            assert_eq!(LuaValue::integer(x.into()), LuaNumber::Integer(x.into()));
+            assert_eq!(LuaNumber::Integer(x.into()), LuaValue::integer(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
 
         // i16
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0i16));
-        assert_eq!(LuaValue::integer(i16::MIN.into()), LuaValue::from(i16::MIN));
-        assert_eq!(LuaValue::integer(i16::MAX.into()), LuaValue::from(i16::MAX));
+        for x in [0, i16::MIN, i16::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x.into()), v);
+            assert_eq!(LuaValue::integer(x.into()), LuaNumber::Integer(x.into()));
+            assert_eq!(LuaNumber::Integer(x.into()), LuaValue::integer(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
 
         // i8
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0i8));
-        assert_eq!(LuaValue::integer(i8::MIN.into()), LuaValue::from(i8::MIN));
-        assert_eq!(LuaValue::integer(i8::MAX.into()), LuaValue::from(i8::MAX));
+        for x in [0, i8::MIN, i8::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x.into()), v);
+            assert_eq!(LuaValue::integer(x.into()), LuaNumber::Integer(x.into()));
+            assert_eq!(LuaNumber::Integer(x.into()), LuaValue::integer(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
 
         // u64
         assert_eq!(LuaValue::integer(0), LuaValue::try_from(0u64).unwrap());
         LuaValue::try_from(u64::MAX).unwrap_err();
 
         // u32
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0u32));
-        assert_eq!(LuaValue::integer(u32::MAX.into()), LuaValue::from(u32::MAX));
+        for x in [0, u32::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x.into()), v);
+            assert_eq!(LuaValue::integer(x.into()), LuaNumber::Integer(x.into()));
+            assert_eq!(LuaNumber::Integer(x.into()), LuaValue::integer(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
 
         // u16
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0u16));
-        assert_eq!(LuaValue::integer(u16::MAX.into()), LuaValue::from(u16::MAX));
+        for x in [0, u16::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x.into()), v);
+            assert_eq!(LuaValue::integer(x.into()), LuaNumber::Integer(x.into()));
+            assert_eq!(LuaNumber::Integer(x.into()), LuaValue::integer(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
 
         // u8
-        assert_eq!(LuaValue::integer(0), LuaValue::from(0u8));
-        assert_eq!(LuaValue::integer(u8::MAX.into()), LuaValue::from(u8::MAX));
+        for x in [0, u8::MAX] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::integer(x.into()), v);
+            assert_eq!(LuaValue::integer(x.into()), LuaNumber::Integer(x.into()));
+            assert_eq!(LuaNumber::Integer(x.into()), LuaValue::integer(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::integer(1), v);
+        }
     }
 
     #[test]
     #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn from_float() {
         // f64
-        assert_eq!(LuaValue::float(0.), LuaValue::from(0.));
-        assert_eq!(LuaValue::float(f64::MIN), LuaValue::from(f64::MIN));
-        assert_eq!(LuaValue::float(f64::MAX), LuaValue::from(f64::MAX));
-        assert_eq!(
-            LuaValue::float(f64::INFINITY),
-            LuaValue::from(f64::INFINITY),
-        );
-        assert_eq!(
-            LuaValue::float(f64::NEG_INFINITY),
-            LuaValue::from(f64::NEG_INFINITY),
-        );
+        for x in [0., f64::MIN, f64::MAX, f64::INFINITY, f64::NEG_INFINITY] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::float(x), v);
+            assert_eq!(LuaValue::float(x), LuaNumber::Float(x));
+            assert_eq!(LuaNumber::Float(x), LuaValue::float(x));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::float(1.), v);
+        }
 
         let f = LuaValue::from(f64::NAN);
         assert!(matches!(f, LuaValue::Number(LuaNumber::Float(x)) if x.is_nan()));
 
         // f32
-        assert_eq!(LuaValue::float(0.), LuaValue::from(0f32));
-        assert_eq!(LuaValue::float(f32::MIN.into()), LuaValue::from(f32::MIN));
-        assert_eq!(LuaValue::float(f32::MAX.into()), LuaValue::from(f32::MAX));
-        assert_eq!(
-            LuaValue::float(f64::INFINITY),
-            LuaValue::from(f32::INFINITY),
-        );
-        assert_eq!(
-            LuaValue::float(f64::NEG_INFINITY),
-            LuaValue::from(f32::NEG_INFINITY),
-        );
+        for x in [0., f32::MIN, f32::MAX, f32::INFINITY, f32::NEG_INFINITY] {
+            let v = LuaValue::from(x);
+            assert_eq!(LuaValue::float(x.into()), v);
+            assert_eq!(LuaValue::float(x.into()), LuaNumber::Float(x.into()));
+            assert_eq!(LuaNumber::Float(x.into()), LuaValue::float(x.into()));
+            assert_ne!(LuaValue::Boolean(false), v);
+            assert_ne!(LuaValue::float(1.), v);
+        }
 
         let f = LuaValue::from(f32::NAN);
         assert!(matches!(f, LuaValue::Number(LuaNumber::Float(x)) if x.is_nan()));

--- a/serde_luaq/src/value/mod.rs
+++ b/serde_luaq/src/value/mod.rs
@@ -1,4 +1,10 @@
 use crate::{LuaNumber, LuaTableEntry};
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32",
+))]
+use static_assertions::assert_eq_size;
 use std::{
     borrow::Cow,
     fmt::{Debug, Formatter},
@@ -126,6 +132,13 @@ pub enum LuaValue<'a> {
     /// [lua3.4.9]: https://www.lua.org/manual/5.4/manual.html#3.4.9
     Table(Vec<LuaTableEntry<'a>>),
 }
+
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32",
+))]
+assert_eq_size!((usize, usize, LuaNumber), LuaValue<'_>);
 
 impl Debug for LuaValue<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/serde_luaq/src/value/mod.rs
+++ b/serde_luaq/src/value/mod.rs
@@ -33,7 +33,8 @@ use std::{
 ///
 /// As a result, you can't use [`LuaValue`][] as a field type or deserialise to it.
 ///
-/// If you want to deserialise Lua to a [`LuaValue`][], use one of the `peg` parsers.
+/// If you want to deserialise Lua to a [`LuaValue`][], use one of
+/// [the `peg` deserialisers][crate#peg-deserialiser].
 #[derive(Clone, PartialEq)]
 pub enum LuaValue<'a> {
     /// Nil value.
@@ -90,7 +91,9 @@ pub enum LuaValue<'a> {
 
     /// Array / record / object type.
     ///
-    /// From the [Lua 5.4 Reference Manual, Section 2.1][lua2.1]:
+    /// ## References
+    ///
+    /// [Lua 5.4 Reference Manual, Section 2.1][lua2.1]:
     ///
     /// > The type _table_ implements associative arrays, that is, arrays that can be indexed not
     /// > only with numbers, but with any value (except `nil`).
@@ -110,7 +113,7 @@ pub enum LuaValue<'a> {
     ///
     /// ## Caveats
     ///
-    /// This library implements tables slightly differently to Lua:
+    /// `serde_luaq` implements tables slightly differently to Lua:
     ///
     /// * A [`LuaValue::Table`] is a sequence ([`Vec`]) of [entries][LuaTableEntry], rather than a
     ///   `Map`.
@@ -120,10 +123,10 @@ pub enum LuaValue<'a> {
     ///
     ///   This allows keys to be repeated, and include non-hashable types.
     ///
-    /// * Table keys may be set to _any_ value, including `nil` and `NaN`.
+    /// * Table keys may be set to _any_ value, including `nil` and [`NaN`][f64::NAN].
     ///
     /// * Table values may be set to `nil`. While Lua's manual claims these are treated as missing,
-    ///   it's possible for `%q`-formatted strings to contain such values.
+    ///   it is possible for `%q`-formatted strings to contain such values.
     ///
     /// When using `serde`, you can still use a table to populate a [`BTreeMap`] or [`Vec`].
     ///

--- a/serde_luaq/tests/common/mod.rs
+++ b/serde_luaq/tests/common/mod.rs
@@ -1,4 +1,3 @@
-//! Tests with Lua literals
 #![allow(dead_code)]
 
 use serde_luaq::{lua_value, return_statement, script, LuaValue};

--- a/serde_luaq/tests/de.rs
+++ b/serde_luaq/tests/de.rs
@@ -385,6 +385,62 @@ fn integers() -> Result {
     Ok(())
 }
 
+/// Hex integers for signed fields overflow as [i64][] only.
+#[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+fn hex_overflow() -> Result {
+    // i8
+    assert_eq!(
+        -1,
+        from_slice::<i8>(b"0xffffffffffffffff", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert_eq!(
+        i8::MIN,
+        from_slice::<i8>(b"0xffffffffffffff80", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert!(from_slice::<i8>(b"0x80", LuaFormat::Value, MAX_DEPTH).is_err());
+    assert!(from_slice::<i8>(b"0xff", LuaFormat::Value, MAX_DEPTH).is_err());
+    assert!(from_slice::<i8>(b"0xffffffffffffff7f", LuaFormat::Value, MAX_DEPTH).is_err());
+
+    // i16
+    assert_eq!(
+        -1,
+        from_slice::<i16>(b"0xffffffffffffffff", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert_eq!(
+        i16::MIN,
+        from_slice::<i16>(b"0xffffffffffff8000", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert!(from_slice::<i16>(b"0x8000", LuaFormat::Value, MAX_DEPTH).is_err());
+    assert!(from_slice::<i16>(b"0xffff", LuaFormat::Value, MAX_DEPTH).is_err());
+    assert!(from_slice::<i16>(b"0xffffffffffff7fff", LuaFormat::Value, MAX_DEPTH).is_err());
+
+    // i32
+    assert_eq!(
+        -1,
+        from_slice::<i32>(b"0xffffffffffffffff", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert_eq!(
+        i32::MIN,
+        from_slice::<i32>(b"0xffffffff80000000", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert!(from_slice::<i32>(b"0x80000000", LuaFormat::Value, MAX_DEPTH).is_err());
+    assert!(from_slice::<i32>(b"0xffffffff", LuaFormat::Value, MAX_DEPTH).is_err());
+    assert!(from_slice::<i32>(b"0xffffffff7fffffff", LuaFormat::Value, MAX_DEPTH).is_err());
+
+    // i64
+    assert_eq!(
+        -1,
+        from_slice::<i64>(b"0xffffffffffffffff", LuaFormat::Value, MAX_DEPTH)?,
+    );
+    assert_eq!(
+        i64::MIN,
+        from_slice::<i64>(b"0x8000000000000000", LuaFormat::Value, MAX_DEPTH)?,
+    );
+
+    Ok(())
+}
+
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn floats() -> Result {

--- a/serde_luaq/tests/de.rs
+++ b/serde_luaq/tests/de.rs
@@ -645,6 +645,42 @@ fn field_naming() -> Result {
         )?
     );
 
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct UnicodeFields {
+        français: i16,
+        español: i16,
+        māori: i16,
+    }
+
+    let expected = UnicodeFields {
+        français: 1,
+        español: 2,
+        māori: 3,
+    };
+
+    assert_eq!(
+        expected,
+        from_slice(
+            "{['français'] = 1, [\"español\"] = 2, [ [[māori]]] = 3}".as_bytes(),
+            LuaFormat::Value,
+            MAX_DEPTH,
+        )?
+    );
+
+    assert!(from_slice::<UnicodeFields>(
+        "{français=1, español=2, māori=3}".as_bytes(),
+        LuaFormat::Value,
+        MAX_DEPTH,
+    )
+    .is_err());
+
+    assert!(from_slice::<UnicodeFields>(
+        "français=1\nespañol=2\nmāori=3\n".as_bytes(),
+        LuaFormat::Script,
+        MAX_DEPTH,
+    )
+    .is_err());
+
     // Numeric key support blocked on https://github.com/serde-rs/serde/issues/2358
     // This also means we can't use a table with implicitly-keyed entries and map it to a numeric
     // key.


### PR DESCRIPTION
* Test Unicode field names. This intentionally doesn't support `LUA_UCID`-style identifiers.
* Implement `PartialEq` between `LuaValue` and `LuaNumber`.
* Add `static_assertions` for various `enum` sizes on `aarch64`, `wasm32` and `x86_64`.
* Add many more examples to the documentation
* Describe various security issues with Lua and this library
