### PR TITLE
Fix unit structs, `serde(flatten)` with `Map<_, Vec<T>>` fields.

### DIFF
--- a/serde_luaq/src/de.rs
+++ b/serde_luaq/src/de.rs
@@ -204,7 +204,10 @@ impl<'de> serde::Deserializer<'de> for LuaValue<'de> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_unit(visitor)
+        match self {
+            LuaValue::Table(t) if t.is_empty() => visitor.visit_unit(),
+            _ => Err(self.invalid_type(&visitor)),
+        }
     }
 
     fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Error>

--- a/serde_luaq/tests/de.rs
+++ b/serde_luaq/tests/de.rs
@@ -833,115 +833,97 @@ fn strings() -> Result {
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn arrays() -> Result {
     let expected = ("hello", "world");
-    assert_eq!(
-        expected,
-        from_slice(b"{'hello', 'world'}", LuaFormat::Value, MAX_DEPTH)?
-    );
-    assert_eq!(
-        expected,
-        from_slice(
-            b"{[1] = 'hello', [2] = 'world'}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
+    let expected_a = ["hello", "world"];
+    let expected_v = vec!["hello", "world"];
+    for b in [
+        b"{'hello', 'world'}".as_slice(),
+        b"{[1] = 'hello', [2] = 'world'}",
+    ] {
+        assert_eq!(
+            expected,
+            from_slice(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+        assert_eq!(
+            expected_a,
+            from_slice::<[&str; 2]>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+        assert_eq!(
+            expected_v,
+            from_slice::<Vec<&str>>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+    }
 
     // Any gaps at the start of the array are filled with nil/None
-    let expected = [None, Some("hello"), Some("world")];
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(b"{nil, 'hello', 'world'}", LuaFormat::Value, MAX_DEPTH)?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{[2] = 'hello', [3] = 'world'}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{nil, nil, nil, [2] = 'hello', [3] = 'world'}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{[3] = 'world', [2] = 'hello'}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
+    let expected = vec![None, Some("hello"), Some("world")];
+    for b in [
+        b"{nil, 'hello', 'world'}".as_slice(),
+        b"{[2] = 'hello', [3] = 'world'}",
+        b"{nil, nil, nil, [2] = 'hello', [3] = 'world'}",
+        b"{[3] = 'world', [2] = 'hello'}",
+    ] {
+        assert_eq!(
+            expected,
+            from_slice::<[Option<&str>; 3]>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+        assert_eq!(
+            expected,
+            from_slice::<Vec<Option<&str>>>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+    }
 
     // Gaps in the middle of the array are filled with nil/None
-    let expected = [Some("hello"), None, Some("world")];
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(b"{'hello', nil, 'world'}", LuaFormat::Value, MAX_DEPTH)?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(b"{'hello', [3] = 'world'}", LuaFormat::Value, MAX_DEPTH)?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{[1] = 'hello', [3] = 'world'}",
-            LuaFormat::Value,
-            MAX_DEPTH
-        )?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{nil, nil, nil, [1] = 'hello', [3] = 'world'}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{[3] = 'world', [1] = 'hello'}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
+    let expected = vec![Some("hello"), None, Some("world")];
+    for b in [
+        b"{'hello', nil, 'world'}".as_slice(),
+        b"{[1] = 'hello', [3] = 'world'}",
+        b"{nil, nil, nil, [1] = 'hello', [3] = 'world'}",
+        b"{[3] = 'world', [1] = 'hello'}",
+    ] {
+        assert_eq!(
+            expected,
+            from_slice::<[Option<&str>; 3]>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+        assert_eq!(
+            expected,
+            from_slice::<Vec<Option<&str>>>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+    }
 
-    // Gaps at the end are not filled
-    let expected = [Some("hello"), Some("world"), None];
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(b"{'hello', 'world', nil}", LuaFormat::Value, MAX_DEPTH)?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{'hello', 'world', [3] = nil}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{'hello', [2] = 'world', [3] = nil}",
-            LuaFormat::Value,
-            MAX_DEPTH
-        )?
-    );
-    assert_eq!(
-        expected,
-        from_slice::<[Option<&str>; 3]>(
-            b"{[1] = 'hello', [2] = 'world', [3] = nil}",
-            LuaFormat::Value,
-            MAX_DEPTH,
-        )?
-    );
+    // Gaps at the end are not filled unless explicitly provided
+    let expected = vec![Some("hello"), Some("world"), None];
+    for b in [
+        b"{'hello', 'world', nil}".as_slice(),
+        b"{'hello', 'world', [3] = nil}",
+        b"{'hello', [2] = 'world', [3] = nil}",
+        b"{[1] = 'hello', [2] = 'world', [3] = nil}",
+    ] {
+        assert_eq!(
+            expected,
+            from_slice::<[Option<&str>; 3]>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+        assert_eq!(
+            expected,
+            from_slice::<Vec<Option<&str>>>(b, LuaFormat::Value, MAX_DEPTH)?,
+            "{}",
+            b.escape_ascii()
+        );
+    }
 
     assert!(
         from_slice::<[Option<&str>; 3]>(b"{'hello', 'world'}", LuaFormat::Value, MAX_DEPTH)

--- a/serde_luaq/tests/de.rs
+++ b/serde_luaq/tests/de.rs
@@ -229,6 +229,23 @@ fn enum_variants() {
         from_slice(lua_value, LuaFormat::Value, MAX_DEPTH).unwrap()
     );
 
+    let lua_return = br#"return {["Tuple"]={1,[2]=2}}"#;
+    let lua_script = b"Tuple = {1,[2]=2}\n";
+    let lua_value = br#"{["Tuple"]={1,[2]=2}}"#;
+    let expected = E::Tuple(1, 2);
+    assert_eq!(
+        expected,
+        from_slice(lua_return, LuaFormat::Return, MAX_DEPTH).unwrap()
+    );
+    assert_eq!(
+        expected,
+        from_slice(lua_script, LuaFormat::Script, MAX_DEPTH).unwrap()
+    );
+    assert_eq!(
+        expected,
+        from_slice(lua_value, LuaFormat::Value, MAX_DEPTH).unwrap()
+    );
+
     let lua_return = br#"return {["Struct"]={["a"]=1}}"#;
     let lua_script = br#"Struct = {["a"]=1}"#;
     let lua_value = br#"{["Struct"]={["a"]=1}}"#;


### PR DESCRIPTION
This fixes two issues:

* A unit struct (`struct A;`) or unit enum variant (`enum B { A }`) should be representable as an empty table, not `nil`.
* Fix using `#[serde(flatten)]` with `Map<_, Vec<T>>` (which failed with `invalid type: map, expected a sequence` when deserialised)

This change makes `LuaTableWrapper::deserialize_any()` try to deserialise things that look like a sequence as a sequence (rather than a map). Unfortunately, it looks like something tries to use `deserialize_any()` on some `flatten` types, so it always takes the auto-detection path... and we can't then make it a map again.

This PR also:

* refactors the array deserialisation tests to try deserialising as a `Vec`, not just a fixed-size array
* improves some error messages

