### PR TITLE
Docs work, LuaTableEntry PartialEq/TryFrom changes

### DIFF
--- a/serde_luaq/src/lib.rs
+++ b/serde_luaq/src/lib.rs
@@ -1,9 +1,11 @@
+//! > **Note:** this library is still a work in progress, and there are no API stability guarantees.
+//!
 //! `serde_luaq` is a library for deserialising (and eventually, serialising) simple, JSON-like data
 //! structures from Lua 5.4 source code, _without requiring Lua itself_.
 //!
 //! The goal is to be able to read state from software (mostly games) which is serialised using
-//! [Lua `%q` formatting][format] (and similar techniques) _without_ requiring arbitrary code
-//! execution.
+//! [Lua `%q` formatting][format] (and similar techniques)
+//! [_without_ requiring arbitrary code execution](#security).
 //!
 //! This library consists of four parts:
 //!
@@ -381,31 +383,6 @@
 //! [Like with tables](#tables-as-structs), if a variant's name is a valid Lua identifier, tables
 //! may be keyed with an identifier instead of a string (eg: `{NewType = 1}`).
 //!
-//! ### Using with older / other versions of Lua
-//!
-//! As `serde_luaq` does not execute Lua code, there are only a small number of compatibility
-//! issues:
-//!
-//! * **Lua 5.3** over/underflows decimal integers that don't fit in a [`i64`][], rather than
-//!   coercing to [`f64`][].
-//!
-//!   Hexadecimal integers over/underflow in both Lua 5.3 and 5.4.
-//!
-//! * **Lua 5.2 and earlier, and Luau** always use [`f64`][] for numbers, and do not have an integer
-//!   subtype.
-//!
-//! * **Lua 5.1 and earlier** allow locale-dependent letters in identifiers (rather than just
-//!   basic Latin), and `goto` is not a reserved keyword.
-//!
-//!   This affects [table entries in the form `{foo = bar}`][LuaTableEntry::NameValue]
-//!   and parsing in script mode.
-//!
-//! * **Luau** also adds type annotations, binary integer literals, separators for all integer
-//!   literals and string interpolation. None of these features are supported by `serde_luaq`.
-//!
-//! * **Ravi** adds type annotations and some other language features, which aren't supported by
-//!   `serde_luaq`.
-//!
 //! ## Security
 //!
 //! While using Lua as a serialisation format is convenient to work with in Lua,
@@ -469,9 +446,10 @@
 //!
 //! ### Maximum table depth
 //!
-//! The maximum table depth argument (`max_depth`) controls how deeply nested a table can be before
-//! being rejected by `serde_luaq`. Set this to the maximum depth of tables that you expect in your
-//! input data.
+//! The `max_depth` argument controls how deeply nested a table can be before being rejected by
+//! `serde_luaq`.
+//!
+//! Set this to the maximum depth of tables that you expect in your input data.
 //!
 //! For example:
 //!
@@ -533,7 +511,55 @@
 //! structures can use **significant amounts of memory** if you're not careful. Check out
 //! [the Rust performance book][rust-perf] for tips.
 //!
+//! ## Lua version compatibility
+//!
+//! `serde_luaq` targets syntax compatibility with Lua 5.4.
+//!
+//! As it does not execute Lua code, there are only a small number of compatibility issues with
+//! older and other versions of Lua.
+//!
+//! ### Lua 5.3
+//!
+//! **Lua 5.3** over/underflows decimal integers that don't fit in a [`i64`][], rather than
+//! coercing to [`f64`][].
+//!
+//! Hexadecimal integers over/underflow in both Lua 5.3 and 5.4.
+//!
+//! ### Lua 5.2
+//!
+//! **Lua 5.2 and earlier, and Luau** always use [`f64`][] for numbers, and do not have an integer
+//! subtype.
+//!
+//! ### Lua 5.1 and earlier
+//!
+//! * `serde_luaq` only allows basic Latin letters in identifiers.
+//!
+//!   Lua 5.1 and earlier allows locale-dependent letters.
+//!
+//! * `serde_luaq` does not allow `goto` as an identifier name.
+//!
+//!   This is not a reserved keyword in Lua 5.1 and earlier.
+//!
+//! * `serde_luaq` allows empty statements in script mode.
+//!
+//!   [This is not allowed in Lua 5.1][empty-statements].
+//!
+//! ### Luau
+//!
+//! Like [Lua 5.2](#lua-5.2), **Luau** uses [`f64`][] for numbers.
+//!
+//! It also adds type annotations, binary integer literals, separators for all integer literals and
+//! string interpolation.
+//!
+//! None of these features are supported by `serde_luaq`.
+//!
+//! ### Ravi
+//!
+//! **Ravi** adds type annotations and some other language features, which aren't supported by
+//! `serde_luaq`.
+//!
 //! [comma]: https://github.com/lua/lua/blob/104b0fc7008b1f6b7d818985fbbad05cd37ee654/testes/literals.lua#L298-L300
+//! [empty-statements]: https://www.lua.org/manual/5.1/manual.html#2.4.1
 //! [flatten]: https://serde.rs/attr-flatten.html
 //! [format]: https://www.lua.org/manual/5.4/manual.html#pdf-string.format
 //! [`peg`]: https://docs.rs/peg/latest/peg/

--- a/serde_luaq/src/table_entry.rs
+++ b/serde_luaq/src/table_entry.rs
@@ -697,9 +697,19 @@ mod test {
                 LuaTableEntry::BooleanValue(v),
             );
 
-            // Conversion
+            // Conversion should use the optimal variant
             assert!(matches!(
                 LuaTableEntry::from(v), LuaTableEntry::BooleanValue(a) if a == v));
+
+            // Conversion with LuaValue
+            assert_eq!(
+                LuaValue::try_from(LuaTableEntry::BooleanValue(v)).unwrap(),
+                LuaValue::Boolean(v),
+            );
+            assert_eq!(
+                LuaValue::try_from(LuaTableEntry::Value(Box::new(LuaValue::Boolean(v)))).unwrap(),
+                LuaValue::Boolean(v),
+            );
 
             // Inequality
             assert_ne!(
@@ -746,6 +756,22 @@ mod test {
             LuaTableEntry::Value(Box::new(LuaValue::Nil)),
         );
         assert_eq!(LuaTableEntry::NilValue, LuaTableEntry::NilValue);
+
+        // Conversion should use the optimal variant
+        assert!(matches!(
+            LuaTableEntry::from(LuaValue::Nil),
+            LuaTableEntry::NilValue
+        ));
+
+        // Conversion with LuaValue
+        assert_eq!(
+            LuaValue::try_from(LuaTableEntry::NilValue).unwrap(),
+            LuaValue::Nil,
+        );
+        assert_eq!(
+            LuaValue::try_from(LuaTableEntry::Value(Box::new(LuaValue::Nil))).unwrap(),
+            LuaValue::Nil,
+        );
     }
 
     #[test]
@@ -769,12 +795,23 @@ mod test {
             LuaTableEntry::NumberValue(LuaNumber::Integer(-123)),
         );
 
+        // Conversion should use the optimal variant
         assert!(matches!(
             LuaTableEntry::from(123),
             LuaTableEntry::NumberValue(LuaNumber::Integer(n)) if n == 123));
         assert!(matches!(
             LuaTableEntry::from(123.456),
             LuaTableEntry::NumberValue(LuaNumber::Float(n)) if n == 123.456));
+
+        // Conversion with LuaValue
+        assert_eq!(
+            LuaValue::try_from(LuaTableEntry::NumberValue(LuaNumber::Integer(123))).unwrap(),
+            LuaValue::integer(123),
+        );
+        assert_eq!(
+            LuaValue::try_from(LuaTableEntry::Value(Box::new(LuaValue::integer(123)))).unwrap(),
+            LuaValue::integer(123),
+        );
     }
 
     #[test]

--- a/serde_luaq/src/table_entry.rs
+++ b/serde_luaq/src/table_entry.rs
@@ -13,13 +13,50 @@ use std::{borrow::Cow, str::from_utf8};
 
 /// Lua [table][LuaValue::Table] entry.
 ///
-/// Reference: <https://www.lua.org/manual/5.4/manual.html#3.4.9>
-#[derive(Debug, Clone, PartialEq)]
+/// This type is the same size as [LuaNumber][] (16 bytes), but some variants require additional
+/// heap allocations in a [`Box`][] (detailed below).
+///
+/// Lua syntax reference: <https://www.lua.org/manual/5.4/manual.html#3.4.9>
+#[derive(Debug, Clone)]
 pub enum LuaTableEntry<'a> {
     /// Table entry in the form: `["foo"] = "bar"` or `[123] = "bar"`
+    ///
+    /// ## Memory requirements
+    ///
+    /// This variant requires an additional heap allocation for 2 [`LuaValue`][]s, which is a
+    /// minimum of 64 bytes on 64-bit systems, or 48 bytes on 32-bit systems.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use serde_luaq::{LuaTableEntry, LuaValue};
+    /// // {["foo"] = "bar"}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::KeyValue(Box::new((
+    ///         LuaValue::String(b"foo".into()),
+    ///         LuaValue::String(b"bar".into()),
+    ///     ))),
+    /// ]);
+    ///
+    /// // {[123] = "bar"}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::KeyValue(Box::new((
+    ///         LuaValue::integer(123),
+    ///         LuaValue::String(b"bar".into()),
+    ///     ))),
+    /// ]);
+    /// ```
     KeyValue(Box<(LuaValue<'a>, LuaValue<'a>)>),
 
     /// Table entry in the form: `foo = "bar"`
+    ///
+    /// ## Memory requirements
+    ///
+    /// This variant requires an additional heap allocation for the identifier name and
+    /// [`LuaValue`][]. This should be slightly smaller than a
+    /// [`KeyValue`][LuaTableEntry::KeyValue].
+    ///
+    /// ## Reference
     ///
     /// > A field of the form `name = exp` is equivalent to `["name"] = exp`.
     ///
@@ -31,31 +68,140 @@ pub enum LuaTableEntry<'a> {
     ///
     /// This is represented as a `str`, as these are valid RFC 3629 UTF-8 on
     /// Lua 5.2 and later with default build settings (`LUA_UCID = 0`).
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use serde_luaq::{LuaTableEntry, LuaValue};
+    /// // {foo = "bar"}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::NameValue(Box::new((
+    ///         "foo".into(),
+    ///         LuaValue::String(b"bar".into()),
+    ///     ))),
+    /// ]);
+    ///
+    /// // NameValue and KeyValue are considered equal
+    /// // ie: {a = 1} == {['a'] = 1}
+    /// assert_eq!(
+    ///     LuaTableEntry::KeyValue(Box::new((
+    ///         LuaValue::String(b"a".into()), LuaValue::integer(1),
+    ///     ))),
+    ///     LuaTableEntry::NameValue(Box::new((
+    ///         "a".into(), LuaValue::integer(1),
+    ///     ))),
+    /// );
+    /// ```
     NameValue(Box<(Cow<'a, str>, LuaValue<'a>)>),
 
     /// Bare table entry without a key: `"bar"`
     ///
+    /// ## Memory requirements
+    ///
+    /// This variant requires an additional heap allocation for a [`LuaValue`][], which is a
+    /// minimum of 32 bytes on 64-bit systems, or 24 bytes on 32-bit systems.
+    ///
+    /// If the contained value is [`nil`][LuaTableEntry::NilValue],
+    /// [`bool`][LuaTableEntry::BooleanValue] or [`LuaNumber`][LuaTableEntry::NumberValue], prefer
+    /// using their respective specialised variants (linked inline, and detailed below), as they
+    /// avoid this heap allocation.
+    ///
+    /// These variants are considered equal with their [`Value`][LuaTableEntry::Value] equivalents.
+    ///
+    /// The `peg` parsers will try to use those variants where possible.
+    ///
+    /// ## Reference
+    ///
     /// > fields of the form `exp` are equivalent to `[i] = exp`, where `i`
     /// > are consecutive numerical integers, starting with 1. Fields in the
     /// > other formats do not affect this counting.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use serde_luaq::{LuaNumber, LuaTableEntry, LuaValue};
+    /// // {"bar"}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::Value(Box::new(
+    ///         LuaValue::String(b"bar".into()),
+    ///     )),
+    /// ]);
+    /// ```
     Value(Box<LuaValue<'a>>),
 
     /// Bare numeric table entry without a key: `1234`.
     ///
-    /// This is a specialisation of the [`Value` variant][LuaTableEntry::Value]
-    /// for [`LuaNumber`][] literals that avoids an extra heap allocation.
+    /// This is a specialisation of the [`Value` variant][LuaTableEntry::Value] for [`LuaNumber`][]
+    /// literals that avoids an extra heap allocation. These are considered equal with their
+    /// [`Value`][LuaTableEntry::Value] equivalents.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use serde_luaq::{LuaNumber, LuaTableEntry, LuaValue};
+    /// // {123}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::NumberValue(LuaNumber::Integer(123)),
+    /// ]);
+    ///
+    /// // Different variants of the same value are considered equal
+    /// assert_eq!(
+    ///     LuaTableEntry::Value(Box::new(
+    ///         LuaValue::integer(123)
+    ///     )),
+    ///     LuaTableEntry::NumberValue(
+    ///         LuaNumber::Integer(123)
+    ///     ),
+    /// );
+    /// ```
     NumberValue(LuaNumber),
 
     /// Bare boolean table entry without a key: `true`.
     ///
-    /// This is a specialisation of the [`Value` variant][LuaTableEntry::Value]
-    /// for [`bool`][] literals that avoids an extra heap allocation.
+    /// This is a specialisation of the [`Value` variant][LuaTableEntry::Value] for [`bool`][]
+    /// literals that avoids an extra heap allocation. These are considered equal with their
+    /// [`Value`][LuaTableEntry::Value] equivalents.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use serde_luaq::{LuaNumber, LuaTableEntry, LuaValue};
+    /// // {true}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::BooleanValue(true),
+    /// ]);
+    ///
+    /// // Different variants of the same value are considered equal
+    /// assert_eq!(
+    ///     LuaTableEntry::Value(Box::new(
+    ///         LuaValue::Boolean(true)
+    ///     )),
+    ///     LuaTableEntry::BooleanValue(true),
+    /// );
+    /// ```
     BooleanValue(bool),
 
     /// Bare `nil` table entry without a key.
     ///
-    /// This is a specialisation of the [`Value` variant][LuaTableEntry::Value]
-    /// for `nil` literals that avoids an extra heap allocation.
+    /// This is a specialisation of the [`Value` variant][LuaTableEntry::Value] for `nil` literals
+    /// that avoids an extra heap allocation. These are considered equal with their
+    /// [`Value`][LuaTableEntry::Value] equivalents.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use serde_luaq::{LuaNumber, LuaTableEntry, LuaValue};
+    /// // {nil}
+    /// let _ = LuaValue::Table(vec![
+    ///     LuaTableEntry::NilValue,
+    /// ]);
+    ///
+    /// // Different variants of the same value are considered equal
+    /// assert_eq!(
+    ///     LuaTableEntry::Value(Box::new(LuaValue::Nil)),
+    ///     LuaTableEntry::NilValue,
+    /// );
+    /// ```
     NilValue,
 }
 
@@ -67,6 +213,7 @@ pub enum LuaTableEntry<'a> {
 assert_eq_size!(LuaNumber, LuaTableEntry<'_>);
 
 impl<'a> LuaTableEntry<'a> {
+    /// Returns `true` if the entry is implicitly-keyed.
     pub const fn implicit_key(&self) -> bool {
         matches!(
             self,
@@ -83,11 +230,20 @@ impl<'a> LuaTableEntry<'a> {
     /// ## Example
     ///
     /// ```rust
-    /// use serde_luaq::{LuaValue, LuaTableEntry};
+    /// # use serde_luaq::{LuaValue, LuaTableEntry};
+    /// assert_eq!(
+    ///     Some(LuaValue::integer(1)),
+    ///     LuaTableEntry::KeyValue(Box::new((LuaValue::integer(1), LuaValue::Boolean(true)))).key()
+    /// );
     ///
-    /// assert_eq!(Some(LuaValue::integer(1)), LuaTableEntry::KeyValue(Box::new((LuaValue::integer(1), LuaValue::Boolean(true)))).key());
-    /// assert_eq!(Some(b"foo".into()), LuaTableEntry::NameValue(Box::new(("foo".into(), LuaValue::Boolean(true)))).key());
-    /// assert_eq!(None, LuaTableEntry::Value(Box::new(LuaValue::Boolean(true))).key());
+    /// assert_eq!(
+    ///     Some(b"foo".into()),
+    ///     LuaTableEntry::NameValue(Box::new(("foo".into(), LuaValue::Boolean(true)))).key()
+    /// );
+    /// assert_eq!(
+    ///     None,
+    ///     LuaTableEntry::Value(Box::new(LuaValue::Boolean(true))).key()
+    /// );
     /// ```
     pub fn key(&'a self) -> Option<LuaValue<'a>> {
         match self {
@@ -413,14 +569,18 @@ impl<'a> TryFrom<LuaTableEntry<'a>> for (Option<i64>, LuaValue<'a>) {
 impl<'a> TryFrom<LuaTableEntry<'a>> for LuaValue<'a> {
     type Error = LuaTableEntry<'a>;
 
-    /// Converts [`LuaTableEntry::Value`] into [`LuaValue`]. Returns `Err` for other
-    /// types.
+    /// Converts keyless [`LuaValue`][] variants into [`LuaValue`].
+    ///
+    /// Returns `Err` for keyed variants.
     ///
     /// This is intended to help convert an `Iterator<Item = LuaTableEntry>`
     /// into an array of [`LuaValue`].
     fn try_from(value: LuaTableEntry<'a>) -> Result<Self, Self::Error> {
         match value {
             LuaTableEntry::Value(v) => Ok(*v),
+            LuaTableEntry::BooleanValue(v) => Ok(LuaValue::Boolean(v)),
+            LuaTableEntry::NumberValue(v) => Ok(LuaValue::Number(v)),
+            LuaTableEntry::NilValue => Ok(LuaValue::Nil),
             other => Err(other),
         }
     }
@@ -433,10 +593,11 @@ impl From<bool> for LuaTableEntry<'_> {
     }
 }
 
-impl From<LuaNumber> for LuaTableEntry<'_> {
-    /// Converts [`LuaNumber`] into [`LuaTableEntry::NumberValue`].
-    fn from(value: LuaNumber) -> Self {
-        Self::NumberValue(value)
+impl<T: Into<LuaNumber>> From<T> for LuaTableEntry<'_> {
+    /// Converts [`LuaNumber`]-compatible values into [`LuaTableEntry::NumberValue`].
+    fn from(value: T) -> Self {
+        let num: LuaNumber = value.into();
+        Self::NumberValue(num)
     }
 }
 
@@ -450,5 +611,228 @@ impl<'a> From<LuaValue<'a>> for LuaTableEntry<'a> {
             LuaValue::Number(n) => Self::NumberValue(n),
             v => Self::Value(Box::new(v)),
         }
+    }
+}
+
+impl PartialEq for LuaTableEntry<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            // Equality of same-discriminant values
+            (Self::KeyValue(a), Self::KeyValue(b)) => a == b,
+            (Self::NameValue(a), Self::NameValue(b)) => a == b,
+            (Self::Value(a), Self::Value(b)) => a == b,
+            (Self::NumberValue(a), Self::NumberValue(b)) => a == b,
+            (Self::BooleanValue(a), Self::BooleanValue(b)) => a == b,
+            (Self::NilValue, Self::NilValue) => true,
+
+            // Key variant representations
+            (Self::KeyValue(kv), Self::NameValue(nv))
+            | (Self::NameValue(nv), Self::KeyValue(kv)) => {
+                // Check the KeyValue's key
+                let kv = kv.as_ref();
+                match &kv.0 {
+                    LuaValue::String(kvk) => {
+                        if kvk.as_ref() != nv.0.as_bytes() {
+                            return false;
+                        }
+                    }
+
+                    // Not a string
+                    _ => return false,
+                }
+
+                // They match, now check the values
+                kv.1 == nv.1
+            }
+
+            // Number variant representations
+            (Self::Value(a), Self::NumberValue(b)) | (Self::NumberValue(b), Self::Value(a)) => {
+                match a.as_ref() {
+                    LuaValue::Number(a) => a == b,
+                    _ => false,
+                }
+            }
+
+            // Boolean variant representations
+            (Self::Value(a), Self::BooleanValue(b)) | (Self::BooleanValue(b), Self::Value(a)) => {
+                match a.as_ref() {
+                    LuaValue::Boolean(a) => a == b,
+                    _ => false,
+                }
+            }
+
+            // Nil variant representations
+            (Self::Value(a), Self::NilValue) | (Self::NilValue, Self::Value(a)) => {
+                matches!(a.as_ref(), LuaValue::Nil)
+            }
+
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    fn equality_bool() {
+        for v in [true, false] {
+            assert_eq!(
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(v))),
+                LuaTableEntry::BooleanValue(v),
+            );
+            assert_eq!(
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(v))),
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(v))),
+            );
+            assert_eq!(
+                LuaTableEntry::BooleanValue(v),
+                LuaTableEntry::BooleanValue(v),
+            );
+
+            // Conversion
+            assert!(matches!(
+                LuaTableEntry::from(v), LuaTableEntry::BooleanValue(a) if a == v));
+
+            // Inequality
+            assert_ne!(
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(!v))),
+                LuaTableEntry::BooleanValue(v),
+            );
+            assert_ne!(
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(v))),
+                LuaTableEntry::BooleanValue(!v),
+            );
+            assert_ne!(
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(v))),
+                LuaTableEntry::Value(Box::new(LuaValue::Boolean(!v))),
+            );
+            assert_ne!(
+                LuaTableEntry::BooleanValue(v),
+                LuaTableEntry::BooleanValue(!v),
+            );
+
+            // Keyed variants are not equal
+            assert_ne!(
+                LuaTableEntry::KeyValue(Box::new((
+                    LuaValue::String(b"".into()),
+                    LuaValue::Boolean(v)
+                ))),
+                LuaTableEntry::BooleanValue(v),
+            );
+            assert_ne!(
+                LuaTableEntry::NameValue(Box::new(("".into(), LuaValue::Boolean(v)))),
+                LuaTableEntry::BooleanValue(v),
+            );
+        }
+    }
+
+    #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    fn equality_nil() {
+        assert_eq!(
+            LuaTableEntry::Value(Box::new(LuaValue::Nil)),
+            LuaTableEntry::NilValue,
+        );
+        assert_eq!(
+            LuaTableEntry::Value(Box::new(LuaValue::Nil)),
+            LuaTableEntry::Value(Box::new(LuaValue::Nil)),
+        );
+        assert_eq!(LuaTableEntry::NilValue, LuaTableEntry::NilValue);
+    }
+
+    #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    fn equality_number() {
+        assert_eq!(
+            LuaTableEntry::Value(Box::new(LuaValue::integer(123))),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(123)),
+        );
+        assert_eq!(
+            LuaTableEntry::Value(Box::new(LuaValue::integer(123))),
+            LuaTableEntry::Value(Box::new(LuaValue::integer(123))),
+        );
+        assert_eq!(
+            LuaTableEntry::NumberValue(LuaNumber::Integer(123)),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(123)),
+        );
+
+        assert_ne!(
+            LuaTableEntry::Value(Box::new(LuaValue::integer(123))),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(-123)),
+        );
+
+        assert!(matches!(
+            LuaTableEntry::from(123),
+            LuaTableEntry::NumberValue(LuaNumber::Integer(n)) if n == 123));
+        assert!(matches!(
+            LuaTableEntry::from(123.456),
+            LuaTableEntry::NumberValue(LuaNumber::Float(n)) if n == 123.456));
+    }
+
+    #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+    fn equality_keyed() {
+        assert_eq!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+        );
+        assert_eq!(
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+        );
+
+        // Different representations of the same value
+        assert_eq!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+        );
+        assert_eq!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+        );
+
+        // Keys differ
+        assert_ne!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::NameValue(Box::new(("b".into(), LuaValue::Boolean(true)))),
+        );
+        assert_ne!(
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("b".into(), LuaValue::Boolean(true)))),
+        );
+        assert_ne!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("b".into(), LuaValue::Boolean(true)))),
+        );
+        assert_ne!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("b".into(), LuaValue::Boolean(true)))),
+        );
+
+        // Values differ
+        assert_ne!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(false)))),
+        );
+        assert_ne!(
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(false)))),
+        );
+        assert_ne!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(false)))),
+        );
+        assert_ne!(
+            LuaTableEntry::NameValue(Box::new(("a".into(), LuaValue::Boolean(true)))),
+            LuaTableEntry::KeyValue(Box::new(("a".into(), LuaValue::Boolean(false)))),
+        );
     }
 }

--- a/serde_luaq/src/value/mod.rs
+++ b/serde_luaq/src/value/mod.rs
@@ -125,8 +125,7 @@ pub enum LuaValue<'a> {
     ///
     /// * Table keys may be set to _any_ value, including `nil` and [`NaN`][f64::NAN].
     ///
-    /// * Table values may be set to `nil`. While Lua's manual claims these are treated as missing,
-    ///   it is possible for `%q`-formatted strings to contain such values.
+    /// * Table values may be set to `nil`.
     ///
     /// When using `serde`, you can still use a table to populate a [`BTreeMap`] or [`Vec`].
     ///
@@ -506,8 +505,6 @@ pub(crate) fn from_utf8_cow_lossy(v: Cow<'_, [u8]>) -> Cow<'_, str> {
 }
 
 /// Converts a `Cow<'a, str>` into a `Cow<'a, [u8]>` while avoiding copying.
-///
-/// This does not attempt to reverse [`maybe_hex_string()`].
 pub(crate) fn to_utf8_cow(v: Cow<'_, str>) -> Cow<'_, [u8]> {
     match v {
         Cow::Borrowed(v) => Cow::Borrowed(v.as_bytes()),

--- a/serde_luaq/tests/basics.rs
+++ b/serde_luaq/tests/basics.rs
@@ -1,12 +1,13 @@
 mod common;
-use serde_luaq::LuaValue;
-
-use crate::common::check;
+use crate::common::{check, MAX_DEPTH};
+use serde_luaq::{script, LuaValue};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 wasm_bindgen_test_configure!(run_in_browser);
+
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
@@ -19,4 +20,52 @@ fn booleans() {
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn nil() {
     check(b"nil", LuaValue::Nil);
+}
+
+#[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
+fn script_expressions() -> Result {
+    let expected = vec![("x", LuaValue::integer(4)), ("y", LuaValue::integer(5))];
+
+    // "Lua has no line terminators"
+    // https://the-ravi-programming-language.readthedocs.io/en/latest/lua-introduction.html#lua-has-no-line-terminators
+    assert_eq!(expected, script(b"x=4 y=5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x = 4 y = 5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4;y=5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x = 4;y = 5", MAX_DEPTH)?);
+
+    // This would be invalid in Lua 5.1
+    // https://www.lua.org/manual/5.1/manual.html#2.4.1
+    assert_eq!(expected, script(b"x=4;;y=5", MAX_DEPTH)?);
+
+    // Different newlines
+    assert_eq!(expected, script(b"x=4\ry=5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\ry=5\r", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\ny=5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\ny=5\n", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\r\ny=5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\r\ny=5\r\n", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\n\ry=5", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\n\ry=5\n\r", MAX_DEPTH)?);
+    assert_eq!(expected, script(b"x=4\n  \n  \n\t  y=5", MAX_DEPTH)?);
+    assert_eq!(
+        expected,
+        script(b"x=\n\n\n\n\r\n\n\r\n4\ny      =\n5", MAX_DEPTH)?
+    );
+
+    // syntax error near y
+    assert!(script(b"x y = 5", MAX_DEPTH).is_err());
+
+    // calls function x with args ('4')
+    assert!(script(b"x '4' y = 5", MAX_DEPTH).is_err());
+
+    // Creates a local variable x (which is set to `nil`), and sets the global y to 5.
+    // Not supported because it uses a visibility/scope modifier (local).
+    assert!(script(b"local x y = 5", MAX_DEPTH).is_err());
+
+    // Creates a local variable x, set to 4, and a global variable y set to 5.
+    // Not supported because it uses a visibility/scope modifier (local).
+    assert!(script(b"local x = 4 y = 5", MAX_DEPTH).is_err());
+
+    Ok(())
 }


### PR DESCRIPTION
* `PartialEq` for `LuaTableEntry` now considers equivalent variant representations as equal:
  * `Value(LuaValue::Nil)) == NilValue`
  * `Value(LuaValue::Boolean(b)) == BooleanValue(b)`
  * `Value(LuaValue::Number(n)) == NumberValue(n)`
* `PartialEq` for `LuaTableEntry` now considers equivalent `KeyValue` and `NameValue` variants to be equal (ie: `{a = 1} == {['a'] == 1}`)
* `TryFrom<LuaTableEntry<'a>> for LuaValue<'a>` now handles `NilValue`, `BooleanValue` and `NumberValue` variants, rather than erroring (and adds a test for this)
* Expand the `LuaTableEntry` docs with examples and memory requirements.
* Rework the Lua compatibility docs, and move them after the "Security" section.
