### PR TITLE
Migrate hex float parsing to hexfloat2 for WASM support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hexfloat2"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befe65164a090041cdf6e0d21a0ec3198d856fbfe2b76e324a073e790bb49f8c"
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +433,7 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "flate2",
+ "hexfloat2",
  "peg",
  "serde",
  "serde_bytes",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ that a JSON parser would implement:
   - [x] [Floats][lua3.1] (`f64` only)
     - [x] Decimal floats with decimal point and optional exponent (`3.14`, `0.314e1`)
     - [x] Decimal floats with mandatory exponent (`3e14`)
-    - [x] Hexadecimal floating points (`0x.ABCDEFp+24`) (*not supported on WASM*)
+    - [x] Hexadecimal floating points (`0x.ABCDEFp+24`) (*not supported on WASM before v0.2.1*)
     - [x] Positive and negative infinity (`1e9999`, `-1e9999`)
     - [x] NaN (`(0/0)`)
 - [x] [Strings][lua3.1]

--- a/serde_luaq/Cargo.toml
+++ b/serde_luaq/Cargo.toml
@@ -18,6 +18,7 @@ default = ["serde_json"]
 serde_json = ["dep:serde_json"]
 
 [dependencies]
+hexfloat2 = "0.1.3"
 peg = "0.8.5"
 serde = "1.0.210"
 serde_json = { version = "1.0.138", optional = true }

--- a/serde_luaq/src/peg_parser.rs
+++ b/serde_luaq/src/peg_parser.rs
@@ -1,7 +1,6 @@
 //! Peg-based Lua parser.
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-use crate::strtod;
 use crate::{wrapping_parse_int, LuaNumber, LuaTableEntry, LuaValue, LUA_KEYWORDS};
+use hexfloat2::parse as hexfloat_parse;
 use std::{borrow::Cow, str::from_utf8};
 
 const BELL: Cow<'static, [u8]> = Cow::Borrowed(b"\x07");
@@ -203,24 +202,14 @@ peg::parser! {
                         // https://github.com/lua/lua/blob/f7439112a5469078ac4f444106242cf1c1d3fe8a/lstrlib.c#L1017
                         // https://github.com/lua/lua/blob/f7439112a5469078ac4f444106242cf1c1d3fe8a/lobject.c#L290
                         // strx2number: https://github.com/lua/lua/blob/f7439112a5469078ac4f444106242cf1c1d3fe8a/lobject.c#L227
-                        // f64::from_str can't parse hex.
-                        // Shell out to C's strtod, because that's easier.
+                        // f64::from_str can't parse hex, hexfloat2 can!
 
-                        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-                        {
-                            // from_utf8 shouldn't error
-                            let n = from_utf8(n).unwrap();
-
-                            let Some(f) = strtod(n) else {
-                                return Err("floating point parse error");
-                            };
-                            Ok(LuaNumber::Float(f))
-                        }
-
-                        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-                        {
-                            return Err("parsing hex floating points is not supported on this platform")
-                        }
+                        // from_utf8 shouldn't error
+                        let n = from_utf8(n).unwrap();
+                        let Ok(f) = hexfloat_parse(n) else {
+                            return Err("hex floating point parse error");
+                        };
+                        Ok(LuaNumber::Float(f))
                     }
                 ) /
 

--- a/serde_luaq/tests/common/mod.rs
+++ b/serde_luaq/tests/common/mod.rs
@@ -37,7 +37,6 @@ pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
     s.extend_from_slice(lua);
 
     let actual = return_statement(&s, MAX_DEPTH).unwrap();
-    assert_eq!("a", n);
 
     if expected.is_nan() {
         assert!(actual.is_nan(), "lua: {}", s.escape_ascii());
@@ -52,7 +51,6 @@ pub fn check<'a>(lua: &'_ [u8], expected: impl Borrow<LuaValue<'a>>) {
     s.extend_from_slice(b"\n");
 
     let actual = return_statement(&s, MAX_DEPTH).unwrap();
-    assert_eq!("a", n);
 
     if expected.is_nan() {
         assert!(actual.is_nan(), "lua: {}", s.escape_ascii());

--- a/serde_luaq/tests/json.rs
+++ b/serde_luaq/tests/json.rs
@@ -198,7 +198,6 @@ fn disallowed_floats() -> Result {
 #[test]
 #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn floats() -> Result {
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     assert_eq!(
         json!(2.3125),
         to_json_value(lua_value(b"0x2.5", MAX_DEPTH)?, &DEFAULT_OPTS)?

--- a/serde_luaq/tests/numerals.rs
+++ b/serde_luaq/tests/numerals.rs
@@ -64,10 +64,6 @@ fn decimal_integers() {
         b"-179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137216",
         LuaValue::float(f64::NEG_INFINITY),
     );
-
-    // We don't support locale-specific integers
-    should_error(b"3,14");
-    should_error(b".4,3");
 }
 
 /// Hex integer values
@@ -169,13 +165,21 @@ fn decimal_floats() {
     // Overflow f64
     check(b"1.8e+308", LuaValue::float(f64::INFINITY));
     check(b"-1.8e+308", LuaValue::float(f64::NEG_INFINITY));
+
+    // We don't support locale-specific floats
+    should_error(b"3,14");
+    should_error(b"3,14e2");
+    should_error(b".4,3");
 }
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 /// Hex floats
 #[test]
+#[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
 fn hex_floats() {
-    use crate::common::should_error;
+    check(b"0x1.", LuaValue::float(1.));
+    check(b"0x1.0", LuaValue::float(1.));
+    should_error(b"0x1.0p");
+    check(b"0x1.0p0", LuaValue::float(1.));
 
     // lua-tests/math.lua, hex
     check(b"0E+1", LuaValue::float(0.));
@@ -202,6 +206,53 @@ fn hex_floats() {
     check(b"0xA.a", LuaValue::float(10f64 + (10. / 16.)));
     check(b"0xa.aP4", LuaValue::float(0xAA.into()));
     check(b"0x.ABCDEFp+24", LuaValue::float(0xabcdef.into()));
+
+    // https://github.com/lifthrasiir/hexf/issues/25
+    // $ lua -e 'print(0x0.1E)'
+    // 0.1171875
+    check(b"0x.1E", LuaValue::float(0.1171875));
+    check(b"0x0.1E", LuaValue::float(0.1171875));
+
+    // https://gitlab.com/pythongirl/hexponent/-/issues/13
+    // (based on https://github.com/lifthrasiir/hexf/issues/24)
+    //
+    // $ lua -e 'print(0x1p-1074)'
+    // 4.9406564584125e-324
+    // $ lua -e 'print(0x10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000p-1474)'
+    // 4.9406564584125e-324
+    //
+    // - hexponent incorrectly rounds both of these to zero
+    // - hexfloat2 allows the first (rounded) form, but not the second
+    //
+    // string.format("%q") produces the first form:
+    //
+    // $ lua -e 'print(string.format("%q", 0x10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000p-1474))'
+    // 0x1p-1074
+    //
+    // So not allowing the second is probably fine.
+    check(b"0x1p-1074", LuaValue::float(4.9406564584125e-324));
+
+    // https://docs.rs/hexfloat2/0.1.3/hexfloat2/
+    // "too many hex digits" is allowed by Lua:
+    //
+    // $ lua -e 'print(0x10000000000000000p20)'
+    // 1.9342813113834e+25
+    //
+    // But string.format("%q") doesn't produce that:
+    //
+    // $ lua -e 'print(string.format("%q", 0x10000000000000000p20))'
+    // 0x1p+84
+    check(b"0x1p84", LuaValue::float(1.9342813113834067e25));
+    check(b"0x1p+84", LuaValue::float(1.9342813113834067e25));
+
+    // Lua prints both these as "1.0", but only the first is equal to 1.0.
+    check(b"0x1.0000000000001p0", LuaValue::float(1.0000000000000002));
+    check(b"0x1.00000000000001p0", LuaValue::float(1.));
+
+    // We don't support locale-specific hex floats
+    should_error(b"0x2,5");
+    should_error(b"0xA,a");
+    should_error(b"0xa,aP4");
 }
 
 /// Special floats


### PR DESCRIPTION
Hex float parsing isn't yet supported by Rust (https://github.com/rust-lang/libs-team/issues/536).

Migrates hex float parsing from the system `strtod` to [`hexfloat2`](https://docs.rs/hexfloat2), which allows us to support hex float parsing on WASM targets. It also supports both parsing and writing hex floats, which would be good when we want to serialise back to Lua.

I had a look at a few options, from https://github.com/rust-lang/rust/issues/1433#issuecomment-1835268324 and other searching:

- [`hexf-parse`](https://docs.rs/hexf-parse/) requires a `p`-exponent (`binary-exponent-part`), which is optional in Lua: https://github.com/lifthrasiir/hexf/issues/25

  ```sh
  $ lua -e 'print(0x0.1E)'
  0.1171875
  ```

  This worked in both `hexfloat2` and `hexponent`.

- [`hexponent`](https://docs.rs/hexponent/) incorrectly parsed `0x1p-1074` as `0.0f64`: https://gitlab.com/pythongirl/hexponent/-/issues/13

  ```sh
  $ lua -e 'print(0x1p-1074)'
  4.9406564584125e-324
  ```

  This worked in `hexfloat2`.

- [`hexfloat2`](https://docs.rs/hexfloat2/) doesn't allow more than 16 hex digits, which is allowed in Lua:

  ```sh
  $ lua -e 'print(0x10000000000000000p20)'
  1.9342813113834e+25
  ```
  
  `hexponent` handled this, but these values don't appear in `string.format("%q")` output... so I can live with this. :)

- [`hexponent`](https://docs.rs/hexponent/) can parse from `&[u8]`, not just `&str`. `hexfloat2` and `hexf` both use `&str`.

This PR also adds more tests, and runs hex float parsing tests on `wasm32` targets.