### PR TITLE
Rewording security docs, reduce `lua_to_json` default maximum table depth to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 `serde_luaq` is a library for deserialising (and eventually, serialising) simple, JSON-equivalent
 data structures from Lua 5.4 source code, _without requiring Lua itself_ (unlike [`mlua`][mlua]).
 
-The goal is to be able to read state from software (mostly games) which is serialised using
-[Lua `%q` formatting][format] (and similar techniques) _without_ requiring arbitrary code execution.
+The goal is to safely read state from software (mostly games) which is serialised using
+[Lua `%q` formatting][format] (and similar techniques) _without_ allowing arbitrary code execution.
 
 This library consists of four parts:
 
@@ -38,7 +38,7 @@ c = {
 }
 ```
 
-And define some a schema using Serde traits:
+Then define some a schema using Serde traits:
 
 ```rust
 #[derive(Deserialize, PartialEq, Debug)]

--- a/serde_luaq/examples/lua_to_json.rs
+++ b/serde_luaq/examples/lua_to_json.rs
@@ -17,7 +17,7 @@ use std::{
 const DEFAULT_SIZE_LIMIT: usize = 64 * 1024 * 1024;
 
 /// Default maximum table depth (`LUAI_MAXCCALLS`).
-const DEFAULT_MAX_DEPTH: u16 = 200;
+const DEFAULT_MAX_DEPTH: u16 = 16;
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 


### PR DESCRIPTION
* Security-related doc rewording
* Note that setting up a custom environment in Lua _does not_ prevent evaluated code from consuming excessive resources
* Fix up some grammar issues
* Reduce `lua_to_json`'s default maximum table depth to 16
